### PR TITLE
docs: update README with log utility, build hashes, and --readme option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ Run command to build your code `npm run build`
 
 #### API options
 
-| Option    | Description                        | Default |
-|-----------|------------------------------------|---------|
-| `--clean` | Clean dist folder before build     | `false` |
-| `--v7`    | CS will be compatible only with v7 | `false` |
+| Option           | Description                                                      | Default |
+|------------------|------------------------------------------------------------------|---------|
+| `--clean`        | Clean dist folder before build                                  | `false` |
+| `--v7`           | CS will be compatible only with v7                              | `false` |
+| `--readme <path>` | Path to README.md file to include in the built script banner    | Auto-detect `README.md` in project root |
 
 ### Basic usage
 
@@ -48,6 +49,42 @@ setTimeout(() => {
 
 ### Utils usage
 
+#### Log utility
+
+Provides logging utilities with log level support for custom scripts. Logs are only visible if their level is greater than or equal to the current log level.
+
+```javascript
+import {
+  log,
+  setLogLevel,
+  getLogLevel,
+  LOG_LEVEL_DEBUG,
+  LOG_LEVEL_INFO,
+  LOG_LEVEL_WARN,
+  LOG_LEVEL_ERROR,
+} from '@metricinsights/cs-helper/utils';
+
+// Set the current log level (defaults to INFO/1)
+// Only logs with level >= current level will be visible
+setLogLevel(LOG_LEVEL_INFO); // or setLogLevel(1) or setLogLevel('info')
+
+// Get current log level
+const currentLevel = getLogLevel(); // Returns: 1
+
+// Log messages with different levels
+log('Debug information', LOG_LEVEL_DEBUG); // Level 0 - NOT visible (current level is 1)
+log('Info message', LOG_LEVEL_INFO);        // Level 1 - VISIBLE ✓
+log('Warning message', LOG_LEVEL_WARN);     // Level 2 - VISIBLE ✓
+log('Error occurred', LOG_LEVEL_ERROR);     // Level 3 - VISIBLE ✓
+
+// Change log level to show debug messages too
+setLogLevel(LOG_LEVEL_DEBUG); // Now level 0
+log('Debug information', LOG_LEVEL_DEBUG); // Level 0 - VISIBLE ✓
+
+// Log levels (lower number = more verbose):
+// debug (0), info (1), warn (2), error (3), emergency (4), silent (10)
+```
+
 #### Data convertor
 
 Contains methods to apply metadata for MI datasets
@@ -58,7 +95,7 @@ import {
   buildMetadataTransformer,
   applyMetadata,
   transformDataset,
-} from '@metricinsights/cs-helper/dist/utils';
+} from '@metricinsights/cs-helper/utils';
 
 async function main() {
   const dataset = await new Promise((resolve, reject) => {
@@ -84,4 +121,14 @@ async function main() {
 }
 
 main();
+```
+
+## Build Output
+
+The built script includes a banner with metadata:
+
+- **Script source hash**: SHA-256 hash (first 16 hex chars) of the main file and all imported files (relative imports only). This helps verify the source code hasn't changed.
+- **Checksum**: SHA-256 hash (first 16 hex chars) of the built output file. To verify the built file hasn't been modified, replace the checksum value with `0000000000000000` in the banner, then hash the file; the result should match the stored checksum.
+
+Both hashes are included automatically in the banner when building your custom script.
 ```


### PR DESCRIPTION
- Add log utility documentation with setLogLevel/getLogLevel examples
- Add visibility comments showing when logs are visible based on log level
- Document script source hash and build checksum in build output
- Add --readme CLI option to API options table
- Fix utils import path (remove /dist/utils)