### PR TITLE
docs: update Linux/Mac checksum calculation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,16 +169,20 @@ Write-Host "Calculated checksum: $checksum"
 **Linux/Mac (bash):**
 
 ```bash
-# Read file and normalize content
+# Read file content
 content=$(cat dist/script.js)
-# Replace tabs with spaces
-content=$(echo "$content" | sed 's/\t/  /g')
-# Normalize line endings to LF
-content=$(echo "$content" | sed 's/\r\n/\n/g' | sed 's/\r/\n/g')
+
+# Replace tabs with two spaces
+content=$(printf '%s' "$content" | sed $'s/\t/  /g')
+
+# Remove CR characters (normalize line endings to LF)
+content=$(printf '%s' "$content" | tr -d '\r')
+
 # Replace checksum placeholder
-content=$(echo "$content" | sed 's/Checksum: [0-9a-f]\{16\}/Checksum: 0000000000000000/')
-# Calculate hash
-checksum=$(echo -n "$content" | sha256sum | cut -d' ' -f1 | cut -c1-16)
+content=$(printf '%s' "$content" | sed 's/Checksum: [0-9a-f]\{16\}/Checksum: 0000000000000000/')
+
+# Calculate hash from exact byte sequence
+checksum=$(printf '%s' "$content" | sha256sum | cut -d' ' -f1 | cut -c1-16)
 echo "Calculated checksum: $checksum"
 ```
 

--- a/README.md
+++ b/README.md
@@ -169,20 +169,15 @@ Write-Host "Calculated checksum: $checksum"
 **Linux/Mac (bash):**
 
 ```bash
-# Read file content
-content=$(cat dist/script.js)
-
-# Replace tabs with two spaces
-content=$(printf '%s' "$content" | sed $'s/\t/  /g')
-
-# Remove CR characters (normalize line endings to LF)
-content=$(printf '%s' "$content" | tr -d '\r')
-
-# Replace checksum placeholder
-content=$(printf '%s' "$content" | sed 's/Checksum: [0-9a-f]\{16\}/Checksum: 0000000000000000/')
-
-# Calculate hash from exact byte sequence
-checksum=$(printf '%s' "$content" | sha256sum | cut -d' ' -f1 | cut -c1-16)
+# Calculate checksum with normalization pipeline (preserves trailing newlines)
+checksum=$(
+  sed $'s/\t/  /g' dist/script.js \
+  | tr -d '\r' \
+  | sed 's/Checksum: [0-9a-f]\{16\}/Checksum: 0000000000000000/' \
+  | sha256sum \
+  | cut -d' ' -f1 \
+  | cut -c1-16
+)
 echo "Calculated checksum: $checksum"
 ```
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,6 @@ checksum=$(
   | cut -c1-16
 )
 echo "Calculated checksum: $checksum"
-echo "Calculated checksum: $checksum"
 ```
 
 **Node.js:**

--- a/README.md
+++ b/README.md
@@ -170,14 +170,25 @@ Write-Host "Calculated checksum: $checksum"
 
 ```bash
 # Calculate checksum with normalization pipeline (preserves trailing newlines)
+# Detect available SHA-256 command
+if command -v sha256sum &> /dev/null; then
+  HASH_CMD="sha256sum"
+elif command -v shasum &> /dev/null; then
+  HASH_CMD="shasum -a 256"
+else
+  echo "Error: No SHA-256 command found" >&2
+  exit 1
+fi
+
 checksum=$(
   sed $'s/\t/  /g' dist/script.js \
   | tr -d '\r' \
   | sed 's/Checksum: [0-9a-f]\{16\}/Checksum: 0000000000000000/' \
-  | sha256sum \
+  | $HASH_CMD \
   | cut -d' ' -f1 \
   | cut -c1-16
 )
+echo "Calculated checksum: $checksum"
 echo "Calculated checksum: $checksum"
 ```
 


### PR DESCRIPTION
Refine the instructions for reading file content and normalizing it before checksum calculation. Replace tabs with two spaces and remove CR characters to ensure consistent line endings. This improves clarity and accuracy for users verifying file integrity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved Linux/macOS checksum calculation instructions with a more robust pipeline approach, including dynamic detection of available SHA-256 commands and enhanced error handling for better cross-platform consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->