### PR TITLE
pp-2813: Fix build and create CLI when run as binary from consuming projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ Run command to build your code `npm run build`
 
 ### Create new script
 
-Scaffold a new custom script project from a template using `cs-helper-create`:
+Scaffold a new custom script project from a template using `cs-helper`:
 
 ```shell
-npx @metricinsights/cs-helper-create [destination]
+npx -p @metricinsights/cs-helper cs-helper-create [destination]
 ```
 
 **How it works:**
@@ -78,7 +78,7 @@ npx @metricinsights/cs-helper-create [destination]
 **Example (non-interactive):**
 
 ```shell
-npx @metricinsights/cs-helper-create -t custom-script-ts -n my-script -d "My custom script" -v 1.0.0 ./my-script
+npx -p @metricinsights/cs-helper cs-helper-create -t custom-script-ts -n my-script -d "My custom script" -v 1.0.0 ./my-script
 ```
 
 ### Basic usage

--- a/bin/build.ts
+++ b/bin/build.ts
@@ -43,17 +43,21 @@ function parsePackageRepository(
   if (normalized.startsWith('https://') || normalized.startsWith('http://')) {
     return normalized;
   }
+
   if (normalized.startsWith('git://')) {
     return normalized.replace(/^git:\/\//, 'https://');
   }
+
   if (normalized.startsWith('ssh://')) {
     // ssh://git@github.com/user/repo.git -> https://github.com/user/repo.git
     return normalized
       .replace(/^ssh:\/\/git@/, 'https://')
       .replace(/^ssh:\/\//, 'https://');
   }
+
   // git@github.com:user/repo.git -> https://github.com/user/repo.git
   const scpMatch = normalized.match(/^git@([^:]+):(.+)$/);
+  
   if (scpMatch) {
     return `https://${scpMatch[1]}/${scpMatch[2]}`;
   }
@@ -62,12 +66,21 @@ function parsePackageRepository(
 }
 
 (async function () {
-  // @ts-ignore
-  const { default: webpack } = (await import('webpack')) as unknown as {
-    default: Webpack;
-  };
-  // @ts-ignore
-  const { default: chalk } = await import('chalk');
+  // Resolve webpack from cs-helper's own node_modules (not the consuming project's).
+  // Use require() with resolved path - dynamic import() gets transpiled to require(fileUrl)
+  // which fails because require() does not accept file:// URLs.
+  const packageRoot = path.resolve(__dirname, '..', '..');
+  const webpackPath = require.resolve('webpack', { paths: [packageRoot] });
+  const webpack = require(webpackPath) as Webpack;
+
+  if (!webpack) {
+    throw new Error(
+      'Failed to load webpack. Ensure @metricinsights/cs-helper is installed with its dependencies.',
+    );
+  }
+
+  // Chalk v5 is ESM; require() returns { default: chalk }
+  const chalk = require('chalk').default ?? require('chalk');
 
   if (!process.argv[2]) {
     throw new Error(chalk.red("Main filename can't be undefined"));

--- a/bin/create.ts
+++ b/bin/create.ts
@@ -249,7 +249,7 @@ function replaceTemplateVar(
 
       copyFilesRecursive(
         templateDir,
-        destination,
+        destinationFolder,
         (filepath) => {
           if (isBinaryFileSync(filepath)) {
             return true;
@@ -282,7 +282,7 @@ function replaceTemplateVar(
       console.log(
         `\nTo start working on your custom script, run the following commands:\n`,
       );
-      console.log(`cd ${destination}`);
+      console.log(`cd ${destinationFolder}`);
       console.log(`npm install`);
       console.log(`npm run build`);
     });

--- a/tsconfig.bin.json
+++ b/tsconfig.bin.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "declaration": true,
     "lib": ["esnext"],
-    "module": "esnext",
+    "module": "commonjs",
     "moduleResolution": "node",
     "removeComments": true,
     "sourceMap": true,


### PR DESCRIPTION
# pp-2813: Fix build and create CLI when run as binary from consuming projects

## Summary

Fixes issues when `cs-helper` runs as a binary from projects that don't have webpack/chalk as dependencies. Also corrects path handling in the create script and updates npx usage docs.

## Changes

### fix(build): resolve webpack from package root and fix chalk ESM interop
- Resolve webpack from cs-helper's own node_modules when run as binary (avoids `webpack.BannerPlugin` undefined)
- Use `require()` instead of dynamic import to avoid file:// URL issues when transpiled to CommonJS
- Handle chalk v5 ESM default export for `require()` (avoids `chalk.green is not a function`)

### fix(create): use resolved path in copyFilesRecursive and cd output
- Pass `destinationFolder` (resolved path) to `copyFilesRecursive` instead of raw `destination`
- Show resolved path in the final `cd` instruction

### docs: fix npx command examples for cs-helper-create
- Update examples from `npx @metricinsights/cs-helper-create` to `npx -p @metricinsights/cs-helper cs-helper-create`

### build: use commonjs module for bin scripts
- Set `tsconfig.bin.json` module to `commonjs` for bin script compilation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated scaffolding command guidance to reflect the new invocation method.

* **Bug Fixes**
  * Improved Git URL format support to handle multiple URL types.
  * Enhanced error handling for missing dependencies.
  * Fixed path references in scaffolding output instructions.
  * Improved compatibility with Chalk v5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->