### PR TITLE
Release: Merge develop into main (v0.6.1-beta.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [0.6.1-beta.1](https://github.com/mi-examples/cs-helper/compare/v0.6.0...v0.6.1-beta.1) (2026-02-24)
+
+
+### Bug Fixes
+
+* **build:** resolve webpack from package root and fix chalk ESM interop ([c7f1822](https://github.com/mi-examples/cs-helper/commit/c7f18220f5dec0a90b5ea13ba91696f2479eee85))
+* **create:** use resolved path in copyFilesRecursive and cd output ([5a9eb12](https://github.com/mi-examples/cs-helper/commit/5a9eb12edaf2c62acf99251381e0e3749af00bd2))
+
 # [0.6.0-beta.1](https://github.com/mi-examples/cs-helper/compare/v0.5.1...v0.6.0-beta.1) (2026-02-24)
 
 

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ Run command to build your code `npm run build`
 
 ### Create new script
 
-Scaffold a new custom script project from a template using `cs-helper-create`:
+Scaffold a new custom script project from a template using `cs-helper`:
 
 ```shell
-npx @metricinsights/cs-helper-create [destination]
+npx -p @metricinsights/cs-helper cs-helper-create [destination]
 ```
 
 **How it works:**
@@ -78,7 +78,7 @@ npx @metricinsights/cs-helper-create [destination]
 **Example (non-interactive):**
 
 ```shell
-npx @metricinsights/cs-helper-create -t custom-script-ts -n my-script -d "My custom script" -v 1.0.0 ./my-script
+npx -p @metricinsights/cs-helper cs-helper-create -t custom-script-ts -n my-script -d "My custom script" -v 1.0.0 ./my-script
 ```
 
 ### Basic usage

--- a/bin/build.ts
+++ b/bin/build.ts
@@ -43,17 +43,21 @@ function parsePackageRepository(
   if (normalized.startsWith('https://') || normalized.startsWith('http://')) {
     return normalized;
   }
+
   if (normalized.startsWith('git://')) {
     return normalized.replace(/^git:\/\//, 'https://');
   }
+
   if (normalized.startsWith('ssh://')) {
     // ssh://git@github.com/user/repo.git -> https://github.com/user/repo.git
     return normalized
       .replace(/^ssh:\/\/git@/, 'https://')
       .replace(/^ssh:\/\//, 'https://');
   }
+
   // git@github.com:user/repo.git -> https://github.com/user/repo.git
   const scpMatch = normalized.match(/^git@([^:]+):(.+)$/);
+  
   if (scpMatch) {
     return `https://${scpMatch[1]}/${scpMatch[2]}`;
   }
@@ -62,12 +66,21 @@ function parsePackageRepository(
 }
 
 (async function () {
-  // @ts-ignore
-  const { default: webpack } = (await import('webpack')) as unknown as {
-    default: Webpack;
-  };
-  // @ts-ignore
-  const { default: chalk } = await import('chalk');
+  // Resolve webpack from cs-helper's own node_modules (not the consuming project's).
+  // Use require() with resolved path - dynamic import() gets transpiled to require(fileUrl)
+  // which fails because require() does not accept file:// URLs.
+  const packageRoot = path.resolve(__dirname, '..', '..');
+  const webpackPath = require.resolve('webpack', { paths: [packageRoot] });
+  const webpack = require(webpackPath) as Webpack;
+
+  if (!webpack) {
+    throw new Error(
+      'Failed to load webpack. Ensure @metricinsights/cs-helper is installed with its dependencies.',
+    );
+  }
+
+  // Chalk v5 is ESM; require() returns { default: chalk }
+  const chalk = require('chalk').default ?? require('chalk');
 
   if (!process.argv[2]) {
     throw new Error(chalk.red("Main filename can't be undefined"));

--- a/bin/create.ts
+++ b/bin/create.ts
@@ -249,7 +249,7 @@ function replaceTemplateVar(
 
       copyFilesRecursive(
         templateDir,
-        destination,
+        destinationFolder,
         (filepath) => {
           if (isBinaryFileSync(filepath)) {
             return true;
@@ -282,7 +282,7 @@ function replaceTemplateVar(
       console.log(
         `\nTo start working on your custom script, run the following commands:\n`,
       );
-      console.log(`cd ${destination}`);
+      console.log(`cd ${destinationFolder}`);
       console.log(`npm install`);
       console.log(`npm run build`);
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@metricinsights/cs-helper",
-  "version": "0.6.0-beta.1",
+  "version": "0.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@metricinsights/cs-helper",
-      "version": "0.6.0-beta.1",
+      "version": "0.6.1-beta.1",
       "license": "ISC",
       "dependencies": {
         "@babel/core": "^7.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metricinsights/cs-helper",
-  "version": "0.6.0-beta.1",
+  "version": "0.6.1-beta.1",
   "description": "Helper for Custom Scripts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tsconfig.bin.json
+++ b/tsconfig.bin.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "declaration": true,
     "lib": ["esnext"],
-    "module": "esnext",
+    "module": "commonjs",
     "moduleResolution": "node",
     "removeComments": true,
     "sourceMap": true,


### PR DESCRIPTION
# Release: Merge develop into main (v0.6.1-beta.1)

## Summary

Release cs-helper v0.6.1-beta.1 to main. Includes fixes for build and create CLI when run as a binary from consuming projects.

## Changes in develop

- **fix(build):** Resolve webpack from package root and fix chalk ESM interop
- **fix(create):** Use resolved path in copyFilesRecursive and cd output
- **docs:** Fix npx command examples for cs-helper-create
- **build:** Use commonjs module for bin scripts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved support for various Git repository URL formats
  * Fixed webpack and Chalk loading issues during build
  * Corrected file path handling in project creation workflow

* **Documentation**
  * Updated README with revised command examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->