### PR TITLE
Release v0.6.1-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.6.1-beta.2](https://github.com/mi-examples/cs-helper/compare/v0.6.1-beta.1...v0.6.1-beta.2) (2026-02-26)
+
+
+### Bug Fixes
+
+* **create:** handle prompts import for CommonJS and ESM ([3858da1](https://github.com/mi-examples/cs-helper/commit/3858da1c220996118a9f2886861d36f40fccaa51))
+
 ## [0.6.1-beta.1](https://github.com/mi-examples/cs-helper/compare/v0.6.0...v0.6.1-beta.1) (2026-02-24)
 
 

--- a/bin/create.ts
+++ b/bin/create.ts
@@ -38,11 +38,12 @@ function replaceTemplateVar(
 (async function () {
   // @ts-ignore
   const { program, Option, Argument } = await import('commander');
+  const promptsModule = await import('prompts');
   const prompts = (
-    (await import('prompts')) as never as {
-      default: typeof import('prompts');
-    }
-  ).default;
+    'default' in promptsModule && typeof promptsModule.default === 'function'
+      ? promptsModule.default
+      : promptsModule
+  ) as typeof import('prompts');
   const {
     readdirSync,
     existsSync,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@metricinsights/cs-helper",
-  "version": "0.6.1-beta.1",
+  "version": "0.6.1-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@metricinsights/cs-helper",
-      "version": "0.6.1-beta.1",
+      "version": "0.6.1-beta.2",
       "license": "ISC",
       "dependencies": {
         "@babel/core": "^7.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metricinsights/cs-helper",
-  "version": "0.6.1-beta.1",
+  "version": "0.6.1-beta.2",
   "description": "Helper for Custom Scripts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Merge `develop` into `main` to release v0.6.1-beta.2.

## Changes

### Bug Fixes

- **create:** handle prompts import for CommonJS and ESM — fixes "prompts is not a function" when running `cs-helper-create` in the CommonJS build output

## Version

- **From:** v0.6.1-beta.1
- **To:** v0.6.1-beta.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved compatibility with both CommonJS and ES module formats for prompt handling, ensuring the feature works across different runtime environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->