### PR TITLE
ai-100: Tooling, AI add-ons for scaffold, API docs, and Playwright tests

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -39,6 +39,9 @@ jobs:
           fi
           echo "Build verification passed"
 
+      - name: Test
+        run: npm test
+
       - name: Configure Git
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,9 @@ jobs:
           fi
           echo "Build verification passed"
 
+      - name: Test
+        run: npm test
+
       - name: Update package version
         run: npm version ${{ steps.version.outputs.version }} --no-git-tag-version
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 dist
 node_modules
 metricinsights-cs-helper-*.tgz
+test-results
 
 .idea
 .vscode

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ npx -p @metricinsights/cs-helper cs-helper-create [destination]
    - **Description** — Package description
    - **Version** — Defaults to `1.0.0`
    - **MI v7** — Whether to target Metric Insights v7 only (not compatible with v6)
+   - **AI assistant files** — Multiselect of available tools (e.g. Cursor rules, Claude project file), when the installed package ships **`ai-addons`**. Skipped when stdin is not a TTY unless you pass **`--ai`** (see below).
 
 3. **Template processing** — Files from the chosen template are copied and placeholders are replaced:
    - `%PACKAGE_NAME%` → package name
@@ -61,9 +62,11 @@ npx -p @metricinsights/cs-helper cs-helper-create [destination]
    - `%V7%` → ` --v7` or empty (for build command)
    - `%PLUGIN_VERSION%` → cs-helper version
 
-4. **Entry file** — `index.js` or `index.ts` is renamed to `{packageName}.js` or `{packageName}.ts`.
+4. **AI assistant add-ons (optional)** — If you select one or more tools (interactively or via **`--ai`**), files from **`ai-addons/<tool>/`** in the package are copied into the new project **after** the template, with the **same** placeholder substitution. Add-ons are optional; omit them if you do not need editor- or assistant-specific files.
 
-5. **Next steps** — The CLI prints instructions to `cd`, `npm install`, and `npm run build`.
+5. **Entry file** — `index.js` or `index.ts` is renamed to `{packageName}.js` or `{packageName}.ts`.
+
+6. **Next steps** — The CLI prints instructions to `cd`, `npm install`, and `npm run build`.
 
 #### Create command options
 
@@ -74,6 +77,9 @@ npx -p @metricinsights/cs-helper cs-helper-create [destination]
 | `-d, --description <text>` | Package description                                | Prompt                  |
 | `-v, --version <version>`  | Package version                                    | `1.0.0`                 |
 | `--v7`                     | Target MI v7 only (not compatible with v6)         | `false`                 |
+| `--ai <tool>`              | Copy files from `ai-addons/<tool>/` (repeatable)   | —                       |
+
+The **`--ai`** option is registered only when the installed package includes an **`ai-addons`** directory. Valid values are listed in **`cs-helper-create --help`** (for example `cursor`, `claude`). In **interactive** mode with a TTY, you get a multiselect if you do not pass **`--ai`**. In **non-interactive** mode (e.g. CI), omit **`--ai`** to skip AI files, or pass one or more **`--ai <tool>`** flags.
 
 **Example (non-interactive):**
 
@@ -81,17 +87,50 @@ npx -p @metricinsights/cs-helper cs-helper-create [destination]
 npx -p @metricinsights/cs-helper cs-helper-create -t custom-script-ts -n my-script -d "My custom script" -v 1.0.0 ./my-script
 ```
 
+**Example with AI assistant files (repeat `--ai` for multiple tools):**
+
+```shell
+npx -p @metricinsights/cs-helper cs-helper-create -t custom-script-ts -n my-script -d "My custom script" -v 1.0.0 --ai cursor --ai claude ./my-script
+```
+
 ### Basic usage
 
 ```javascript
 import { cs, parseParams } from '@metricinsights/cs-helper';
 
-const parsedParams = parseParams({ defaultValue: 1 }); // { defaultValue: 1 } & cs.params
+const parsedParams = parseParams({ defaultValue: 1 });
+// Merged object: defaults plus any keys from cs.parameters (runtime wins on conflicts)
 
 setTimeout(() => {
   cs.close();
 }, 1000);
 ```
+
+### `parseParams`
+
+Use **`parseParams(defaultParams?)`** to combine **default values** you define in code with **runtime parameters** from the host (**`cs.parameters`**). Merge order is: start from `defaultParams`, then apply **`cs.parameters`** so values configured for the script in Metric Insights override defaults for the same keys.
+
+The function returns that merged object and also assigns it to **`cs.parsedParams`** (and to the same property on the global object in browser-like environments) so the resolved map is available everywhere without passing it manually.
+
+In **TypeScript**, pass an explicit generic so the build can document your parameters accurately:
+
+```typescript
+const params = parseParams<{
+  region: string;
+  limit: number;
+  enabled: boolean;
+}>({
+  region: 'us',
+  limit: 100,
+  enabled: true,
+});
+```
+
+Only **`string`**, **`number`**, and **`boolean`** values are supported for parameter types (MI passes scalar values). At build time, the cs-helper CLI scans `parseParams` usage to generate the **Params Base64** banner block and the parameter tables in the [Build Output](#build-output) section—see **Params Base64** there for what is embedded.
+
+### Backend HTTP requests (`runApiRequest`)
+
+Use **`cs.runApiRequest(url, settings?)`** for Metric Insights backend APIs. The host injects API authentication and provides the transport layer. Build URLs from **`cs.homeSite`** (or **`customScript.homeSite`**) plus the API path—see the **Data convertor** example below.
 
 ### Utils usage
 
@@ -146,7 +185,7 @@ import {
 async function main() {
   const dataset = await new Promise((resolve, reject) => {
     cs.runApiRequest(
-      `/api/dataset_data?dataset=${1}`,
+      `${cs.homeSite.replace(/\/?$/, '/')}api/dataset_data?dataset=${1}`,
       Object.assign({}, params, {
         success: resolve,
         error: reject,

--- a/ai-addons/claude/CLAUDE.md
+++ b/ai-addons/claude/CLAUDE.md
@@ -1,0 +1,142 @@
+# Metric Insights custom script — %PACKAGE_NAME%
+
+This repository is a **Metric Insights custom script** created with `@metricinsights/cs-helper`.
+
+## Commands
+
+- **Install:** `npm install`
+- **Build:** `npm run build` (bundles the script for Metric Insights; `dist/` is the output)
+
+## Compatibility (v6 vs v7)
+
+The **`npm run build`** script passes `%V7%` (either nothing or ` --v7` for webpack). That selects how the helper and polyfills are wired.
+
+### Metric Insights v6 (default build, no `--v7`)
+
+- **Runtime:** PhantomJS (legacy headless browser).
+- **Language level:** Treat the environment as **old ES5-era** code. The bundle uses Babel with **`targets: "ie 11"`** and webpack **`target: ["web", "es5"]`** so syntax is transpiled down, but **not every modern API** is available or polyfilled.
+- **Polyfills from cs-helper (v6 path):** the helper pulls in a small set (e.g. `Object.assign`, `Array.prototype.find`, `Promise`, `String.prototype.includes` via the v6 polyfill entry). **Anything beyond that is not guaranteed**—avoid newer builtins unless you add your own polyfills or verify they compile and run.
+
+### Metric Insights v7 (`--v7` / v7-only build)
+
+- **Runtime:** **Puppeteer** with a current Chromium stack (MI tracks updates).
+- **Language level:** Babel **`targets: { chrome: "97" }`** with **`useBuiltIns: "entry"`** and **core-js 3.x**, plus webpack **`target: ["web", "es2023"]`**. You can use modern JavaScript much more freely than on v6; still prefer patterns that match a recent Chromium.
+
+## Logging (important)
+
+**Do not use `console.log`, `console.warn`, `console.error`, or other `console` methods** for output you need to see in Metric Insights. The console may exist, but **you typically cannot inspect that output** in the MI UI or run logs.
+
+Use one of these instead:
+
+1. **`cs.log('message')`** — `cs` is the exported `customScript` object from `@metricinsights/cs-helper` (see the scaffolded entry file).
+2. **`customScript.log('message')`** — same global API MI injects at runtime.
+3. **Leveled helper:** `import { log, setLogLevel, … } from '@metricinsights/cs-helper/utils'` — the `log` helper forwards to `customScript.log` (with batching and levels); use this when you want log levels and filtering.
+
+For failures, use **`cs.error(...)`** (and **`cs.result(...)`** / **`cs.close()`** as in the template) so behavior and diagnostics stay visible through MI’s channels.
+
+## Backend HTTP requests (`cs.runApiRequest`)
+
+**Use `cs.runApiRequest(url, settings?)` (or `customScript.runApiRequest`) for all Metric Insights backend HTTP calls.** Do not use raw `fetch`, `XMLHttpRequest`, or manual AJAX for normal API access unless you have a rare, documented exception.
+
+### Authentication
+
+Metric Insights injects API authentication for you. Each request includes an HTTP header:
+
+- **`token`:** the script API token (same value as **`cs.apiToken`**).
+
+Do not set or replace this header yourself for standard backend calls.
+
+### API token lifetime and refresh
+
+The script **`token`** lifetime is **configured on the Metric Insights server** (administration / security policy). There is **no fixed TTL in the client**—always treat expiry as **server-defined**.
+
+In practice, lifetimes are **often at least several minutes** (commonly **not shorter than about 5 minutes**), but **do not rely on a specific number** without confirming your environment.
+
+If the script can **run longer than the token remains valid** (loops, retries, long waits, batch jobs), you should **design explicit token refresh logic**:
+
+1. Call **`GET`** **`/api/get_token`** against the same instance (full URL: **`cs.homeSite`** / **`customScript.homeSite`** + `api/get_token`, with the same URL rules as other backend calls).
+2. Parse the JSON body: **`{ token: string; expires: string }`** — use the new **`token`** for subsequent API traffic and use **`expires`** (host-defined format, often a timestamp or ISO string) to decide **when** to refresh before the next call fails with an auth error.
+
+Wire refresh into your **`runApiRequest`** / **`buildRequest`** flow (e.g. refresh before long phases, or on 401 if your host returns it). If you are unsure how the refreshed **`token`** is applied on each request in your MI version, confirm with Metric Insights documentation or support.
+
+### Implementation (jQuery.ajax)
+
+`runApiRequest` is a **wrapper around jQuery.ajax**:
+
+| MI build | Runtime   | jQuery (ajax) |
+| -------- | --------- | ------------- |
+| v6 (no `--v7` in `npm run build`) | PhantomJS | **1.2.x** |
+| v7 (`--v7`) | Puppeteer / Chromium | **3.x** |
+
+The optional **`settings`** argument uses the same shape as **jQuery ajax** options: `success`, `error`, `type`, `data`, `contentType`, etc., depending on what the MI host merges in.
+
+### URLs
+
+Backend URLs must target the Metric Insights instance. Build the request URL from **`cs.homeSite`** or **`customScript.homeSite`** (MI base URL, e.g. `https://web:<port>/`) plus the API path—do not rely on a bare relative path unless you know the host resolves it correctly.
+
+Example:
+
+```javascript
+const url = cs.homeSite.replace(/\/?$/, '/') + 'api/dataset_data?dataset=1';
+
+cs.runApiRequest(url, {
+  success: function (data) {
+    cs.log(JSON.stringify(data));
+  },
+  error: function (xhr, status, err) {
+    cs.error(String(err || status));
+  },
+});
+```
+
+### Promise wrapper (optional pattern)
+
+You can wrap **`runApiRequest`** in a **`Promise`** and pass **paths relative to `homeSite`** (same rules as above: always resolve the MI base URL correctly).
+
+- Prefer a small **`joinHomeAndPath`** (or equivalent) so **`cs.homeSite`** with or without a trailing slash does not get concatenated wrongly with **`path`**.
+- **`RequestParams`** mirrors jQuery ajax fields you use (`type`, `headers`, `data`, …). Spread **`params`** into the second argument, then attach **`success`** / **`error`** so the Promise **resolves** / **rejects** — otherwise the request never completes the Promise.
+
+```typescript
+import { cs } from '@metricinsights/cs-helper';
+
+export type RequestParams = {
+  type?: 'GET' | 'POST' | 'PUT' | 'DELETE';
+  headers?: Record<string, string>;
+  data?: string;
+  [p: string]: any;
+};
+
+function joinHomeAndPath(path: string): string {
+  const base = cs.homeSite.replace(/\/?$/, '/');
+  return base + path.replace(/^\//, '');
+}
+
+function buildRequest<T extends {} = any>(
+  path: string,
+  params: RequestParams = {},
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    cs.runApiRequest(joinHomeAndPath(path), {
+      ...params,
+      success: (data) => resolve(data as T),
+      error: (_xhr, _status, err) => {
+        reject(err != null ? err : new Error(String(_status)));
+      },
+    });
+  });
+}
+```
+
+## Finishing the script (`cs.close`)
+
+- The script must end by calling **`cs.close()`** when work is done (success or controlled failure).
+- **Best practice:** schedule **`cs.close()` inside `setTimeout(..., 500)`** (e.g. a small `scheduleClose()` helper) so Metric Insights can flush **`cs.result`** / logs before teardown.
+- **Safety timeout:** keep a **maximum execution window** by passing **`scriptTimeout`** in **milliseconds** (ms) from script parameters and using e.g. `setTimeout(..., scriptTimeout)` so that if the script never finishes normally, you **`cs.log`** and then call **`cs.close()`** (again after the usual short delay), avoiding stuck runs.
+
+## Project metadata
+
+- Package version: **%PACKAGE_VERSION%** — description: **%PACKAGE_DESCRIPTION%**.
+- cs-helper version at scaffold time: **%PLUGIN_VERSION%**.
+- v7-only build when the project was created with **`--v7`** (see `package.json` **`build`** script: `%V7%`).
+
+Refer to **`README.md`** and **`src/`** for API surface; **backend HTTP details** for assistants live in this file and **`.cursor/rules/`**.

--- a/ai-addons/cursor/.cursor/rules/metric-insights-custom-script.mdc
+++ b/ai-addons/cursor/.cursor/rules/metric-insights-custom-script.mdc
@@ -1,0 +1,53 @@
+---
+description: Metric Insights custom script runtime, logging, runApiRequest, token TTL / refresh (GET api/get_token)
+globs: src/**/*.js,src/**/*.ts,*.js,*.ts
+---
+
+# Metric Insights custom script (%PACKAGE_NAME%)
+
+Scaffolded with `cs-helper`. Build: `npm run build` → `dist/`. The build script uses `%V7%` in `package.json` when targeting v7 only.
+
+## Runtime
+
+### v6 (default; no `--v7` in build)
+
+- **PhantomJS** in Metric Insights.
+- Assume **legacy ES5-era** execution. The packager uses Babel **`targets: "ie 11"`** and webpack **`es5`**; **polyfills from the helper cover only a subset** (e.g. `Object.assign`, `Array.prototype.find`, `Promise`, `String.prototype.includes`). **Do not assume** full ES2015+ unless transpiled or polyfilled explicitly.
+
+### v7 (`--v7` build)
+
+- **Puppeteer** / modern Chromium in MI.
+- Babel **`chrome: 97`** + **core-js** (`useBuiltIns: "entry"`), webpack **`es2023`**. Modern JS is generally fine; align with current Chromium behavior.
+
+## Backend HTTP — `cs.runApiRequest`
+
+**Use `cs.runApiRequest(url, settings?)` for every MI backend HTTP call** (not raw `fetch` / XHR by default).
+
+- **Auth:** MI injects header **`token`:** same value as **`cs.apiToken`**. Do not set it manually for normal API use.
+- **Token TTL:** Server-configured; often **≥ ~5 minutes** in typical setups, but **verify** your policy. Long-running scripts should implement **refresh**: **`GET`** **`/api/get_token`** → JSON **`{ token: string; expires: string }`**, then continue API calls with refreshed credentials per your MI version (schedule using **`expires`**).
+- **Stack:** Wrapper over **jQuery.ajax** — **jQuery 1.2.x** on v6 (PhantomJS), **jQuery 3.x** on v7 (Puppeteer). **`settings`** = jQuery ajax options (`success`, `error`, `type`, `data`, …).
+- **URL:** Build from **`cs.homeSite`** or **`customScript.homeSite`** + API path (MI instance base + path). Example: `cs.homeSite.replace(/\/?$/, '/') + 'api/...'` then pass to `runApiRequest`.
+
+```javascript
+cs.runApiRequest(cs.homeSite.replace(/\/?$/, '/') + 'api/dataset_data?dataset=1', {
+  success: (data) => cs.log(JSON.stringify(data)),
+  error: (xhr, status, err) => cs.error(String(err || status)),
+});
+```
+
+### Optional: `Promise` wrapper
+
+- Define **`RequestParams`** (`type`, `headers`, `data`, … + index signature for other jQuery ajax fields).
+- Add **`joinHomeAndPath(path)`**: normalize **`cs.homeSite`** with a trailing slash, strip a leading slash from **`path`**, concatenate.
+- **`buildRequest(path, params)`** → **`new Promise`** and **`cs.runApiRequest(..., { ...params, success, error })`** — you must wire **`success`** / **`error`** or the Promise never settles.
+
+## Logging
+
+**Never rely on `console.*` for output users need to see** — it may run, but **results are not visible** in normal MI workflows.
+
+Use:
+
+- **`cs.log(...)`** from `@metricinsights/cs-helper`, or **`customScript.log(...)`**
+- **`import { log } from '@metricinsights/cs-helper/utils'`** for leveled logging (still goes through MI’s log path)
+
+Use **`cs.error`**, **`cs.result`**, and **`cs.close`** to finish. Always end runs with **`cs.close()`**; prefer wrapping it in **`setTimeout(..., 500)`** so MI can flush output. Use a **parameter-driven hang timeout**: read **`scriptTimeout`** (**milliseconds**) from script params and pass it to **`setTimeout`** so a stuck script **`cs.log`s** and then closes.

--- a/bin/create.ts
+++ b/bin/create.ts
@@ -106,6 +106,7 @@ function replaceTemplateVar(
   }
 
   const templatesDirectory = path.resolve(__dirname, '..', '..', 'templates');
+  const aiAddonsDirectory = path.resolve(__dirname, '..', '..', 'ai-addons');
   const pluginPackageJson = JSON.parse(
     readFileSync(path.resolve(__dirname, '..', '..', 'package.json'), {
       encoding: 'utf-8',
@@ -120,11 +121,20 @@ function replaceTemplateVar(
     .filter((dirent) => dirent.isDirectory())
     .map((dirent) => dirent.name);
 
+  const aiAddons = existsSync(aiAddonsDirectory)
+    ? readdirSync(aiAddonsDirectory, {
+        encoding: 'utf-8',
+        withFileTypes: true,
+      })
+        .filter((dirent) => dirent.isDirectory())
+        .map((dirent) => dirent.name)
+    : [];
+
   function dirIsEmpty(path: string): boolean {
     return readdirSync(path).length === 0;
   }
 
-  const cli = program
+  program
     .addOption(
       new Option('-t, --template <template>', 'Template name').choices(
         templates,
@@ -140,7 +150,23 @@ function replaceTemplateVar(
         '--v7, --version-7',
         'Create custom script for MI v7 (not compatible with v6)',
       ),
-    )
+    );
+
+  if (aiAddons.length > 0) {
+    program.addOption(
+      new Option(
+        '--ai <tool>',
+        'Include AI assistant files from ai-addons (repeatable)',
+      )
+        .choices(aiAddons)
+        .argParser((value: string, previous: string[] | undefined) => [
+          ...(previous ?? []),
+          value,
+        ]),
+    );
+  }
+
+  program
     .addArgument(
       new Argument('[destination]', 'Custom script folder destination').default(
         '.',
@@ -156,6 +182,7 @@ function replaceTemplateVar(
         description?: string;
         version?: string;
         v7?: boolean;
+        ai?: string[];
       };
 
       const destinationFolder = path.resolve(process.cwd(), destination);
@@ -238,6 +265,37 @@ function replaceTemplateVar(
           )
         ).value as boolean);
 
+      let selectedAiAddons: string[];
+
+      if (aiAddons.length === 0) {
+        selectedAiAddons = [];
+      } else if (opts.ai !== undefined) {
+        selectedAiAddons = [...new Set(opts.ai)];
+      } else if (process.stdin.isTTY) {
+        selectedAiAddons =
+          (
+            (await prompts(
+              {
+                name: 'value',
+                type: 'multiselect',
+                message: 'Include AI assistant files:',
+                choices: aiAddons.map((name) => ({
+                  title: name,
+                  value: name,
+                })),
+                hint: '- Space to select. Enter to confirm',
+              },
+              { onCancel },
+            )) as { value?: string[] }
+          ).value ?? [];
+      } else {
+        selectedAiAddons = [];
+      }
+
+      selectedAiAddons = selectedAiAddons.filter((name) =>
+        aiAddons.includes(name),
+      );
+
       const replaceMap = {
         '%PACKAGE_NAME%': packageName,
         '%PACKAGE_VERSION%': version,
@@ -278,6 +336,35 @@ function replaceTemplateVar(
         },
       );
 
+      for (const addonName of selectedAiAddons) {
+        const addonDir = path.resolve(aiAddonsDirectory, addonName);
+
+        if (!existsSync(addonDir)) {
+          continue;
+        }
+
+        copyFilesRecursive(
+          addonDir,
+          destinationFolder,
+          (filepath) => {
+            if (isBinaryFileSync(filepath)) {
+              return true;
+            }
+
+            let fileContent = readFileSync(filepath, {
+              encoding: 'utf-8',
+              flag: 'r',
+            });
+
+            for (const [name, value] of Object.entries(replaceMap)) {
+              fileContent = replaceTemplateVar(fileContent, { name, value });
+            }
+
+            return fileContent;
+          },
+        );
+      }
+
       console.log('Done!');
 
       console.log(
@@ -288,5 +375,5 @@ function replaceTemplateVar(
       console.log(`npm run build`);
     });
 
-  cli.parse();
+  program.parse();
 })();

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,14 +21,15 @@
         "prompts": "^2.4.2",
         "string-includes-polyfill": "^1.0.6",
         "ts-loader": "^9.5.7",
-        "typescript": "^5.9.3",
-        "webpack": "^5.105.4"
+        "typescript": "^6.0.2",
+        "webpack": "^5.106.1"
       },
       "bin": {
         "cs-helper": "dist/bin/build.js",
         "cs-helper-create": "dist/bin/create.js"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
         "@types/jquery": "^3.5.34",
@@ -36,7 +37,7 @@
         "@types/prompts": "^2.4.9",
         "brace-expansion": "5.0.5",
         "picomatch": "4.0.4",
-        "prettier": "^3.8.1",
+        "prettier": "^3.8.2",
         "semantic-release": "^25.0.3"
       }
     },
@@ -1793,6 +1794,22 @@
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^27.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -4064,6 +4081,21 @@
       },
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -7342,10 +7374,42 @@
         "node": ">=4"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/prettier": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.2.tgz",
+      "integrity": "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -8642,9 +8706,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -8859,9 +8923,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/webpack": {
-      "version": "5.105.4",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.4.tgz",
-      "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
+      "version": "5.106.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.1.tgz",
+      "integrity": "sha512-EW8af29ak8Oaf4T8k8YsajjrDBDYgnKZ5er6ljWFJsXABfTNowQfvHLftwcepVgdz+IoLSdEAbBiM9DFXoll9w==",
       "license": "MIT",
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",

--- a/package.json
+++ b/package.json
@@ -8,12 +8,14 @@
     "postinstall": "node scripts/sync-npm-bundled-patches.js",
     "prepare": "node scripts/sync-npm-bundled-patches.js",
     "build": "npm run build:sources && npm run build:bin",
-    "postbuild": "npm pack",
+    "postbuild": "npm pack && node scripts/postbuild.js",
     "build:sources": "tsc",
     "build:bin": "tsc --project tsconfig.bin.json",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "playwright test",
     "release": "semantic-release",
-    "version": "npm version --commit-hooks false --git-tag-version false"
+    "version": "npm version --commit-hooks false --git-tag-version false",
+    "test:headed": "playwright test --headed",
+    "test:ui": "playwright test --ui"
   },
   "exports": {
     ".": {
@@ -50,6 +52,7 @@
     "dist/",
     "scripts/sync-npm-bundled-patches.js",
     "templates",
+    "ai-addons",
     "README.md",
     "CHANGELOG.md"
   ],
@@ -73,6 +76,7 @@
     "undici": ">=7.24.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@types/jquery": "^3.5.34",
@@ -80,7 +84,7 @@
     "@types/prompts": "^2.4.9",
     "brace-expansion": "5.0.5",
     "picomatch": "4.0.4",
-    "prettier": "^3.8.1",
+    "prettier": "^3.8.2",
     "semantic-release": "^25.0.3"
   },
   "dependencies": {
@@ -95,8 +99,8 @@
     "prompts": "^2.4.2",
     "string-includes-polyfill": "^1.0.6",
     "ts-loader": "^9.5.7",
-    "typescript": "^5.9.3",
-    "webpack": "^5.105.4"
+    "typescript": "^6.0.2",
+    "webpack": "^5.106.1"
   },
   "bugs": {
     "url": "https://github.com/mi-examples/cs-helper/issues"

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -1,0 +1,10 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './test',
+  testMatch: ['**/*.spec.mjs'],
+  fullyParallel: true,
+  workers: process.env.CI ? '100%' : '25%',
+  reporter: 'list',
+  timeout: 60_000,
+});

--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -1,0 +1,35 @@
+import { readFileSync, copyFileSync, readdirSync, statSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(__dirname, '..');
+
+// Read package name from package.json
+const pkg = JSON.parse(readFileSync(join(rootDir, 'package.json'), 'utf8'));
+const packName = pkg.name.replace(/^@/, '').replace(/\//g, '-');
+
+// Find latest .tgz file matching the package
+const tgzFiles = readdirSync(rootDir)
+  .filter((f) => f.endsWith('.tgz') && f.startsWith(packName))
+  .map((f) => ({
+    name: f,
+    path: join(rootDir, f),
+    mtime: statSync(join(rootDir, f)).mtime,
+  }))
+  .sort((a, b) => b.mtime - a.mtime);
+
+if (tgzFiles.length === 0) {
+  console.error("No pack file found. Run 'npm pack' first.");
+  process.exit(1);
+}
+
+const latest = tgzFiles[0];
+const latestName = latest.name;
+
+// Replace version with "latest" in filename (e.g. pkg-1.0.0.tgz -> pkg-latest.tgz)
+const latestNameNew = latestName.replace(/-[\d.]+(-[a-z0-9.-]+)?\.tgz$/, '-latest.tgz');
+const destPath = join(rootDir, latestNameNew);
+
+copyFileSync(latest.path, destPath);
+console.log(`Copied ${latestName} -> ${latestNameNew}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,53 +2,139 @@ import './polyfill';
 
 type ParametersType = Record<string, string | number | boolean>;
 
+/**
+ * Runtime surface injected by the Metric Insights custom script host. Your bundle runs with a global
+ * **`customScript`** instance (see {@link cs}) exposing identity, configuration, logging, HTTP access, and lifecycle.
+ *
+ * Property availability and exact behavior can depend on the MI version; treat optional fields defensively.
+ */
 export type CustomScript = {
+  /**
+   * API token for the authenticated user/context running this script, as configured in Metric Insights.
+   */
   apiToken: string;
 
+  /**
+   * Identifier of this custom script definition in the MI instance.
+   */
   customScriptId: number;
 
+  /**
+   * Identifier of the current script run’s log entry (correlates this execution with MI logging).
+   */
   customScriptRunLogId: number;
 
+  /**
+   * Raw parameter values supplied by the host (for example from the script’s MI configuration). Keys are parameter
+   * names; values are scalars only. Merged with your defaults by {@link parseParams}.
+   */
   parameters?: ParametersType;
 
+  /**
+   * Last merged parameter map written by {@link parseParams}: defaults from code combined with {@link CustomScript.parameters}.
+   * Undefined until `parseParams` runs.
+   */
   parsedParams?: ParametersType;
 
   /**
-   * MI instance's URL
+   * Base URL of the Metric Insights web instance (scheme, host, port, trailing path as provided). Join with API paths
+   * for {@link CustomScript.runApiRequest}. Normalize a trailing slash on `homeSite`, then append paths such as
+   * `api/dataset_data?...`.
    */
   homeSite: string;
 
+  /**
+   * Portal-wide constants from the MI instance (strings, numbers, or booleans). Known keys include the documented
+   * fields below; additional keys may appear depending on configuration.
+   */
+  constants: {
+    /**
+     * Public hostname of the MI deployment.
+     */
+    HOSTNAME: string;
+
+    /**
+     * Configured portal display name.
+     */
+    PORTAL_NAME: string;
+
+    /**
+     * Maximum total size of digest attachments, as a string (byte limit semantics defined by MI).
+     */
+    DIGEST_MAX_ATTACHMENTS_SIZE: string;
+
+    [key: string]: string | number | boolean;
+  };
+
+  /**
+   * Performs an HTTP request to the Metric Insights backend. The host attaches credentials and uses the platform
+   * transport (commonly a jQuery.ajax-style API). Pass URL and optional settings such as `success`, `error`, `method`,
+   * and request body fields as supported by your MI version.
+   *
+   * @param url Request URL—often built from {@link CustomScript.homeSite} plus an API path.
+   * @param settings Optional request options (e.g. callbacks and payload). Shape depends on the host implementation.
+   * @returns Opaque return value from the host (often a jqXHR-like object where applicable).
+   */
   runApiRequest: (url: string, settings?: any) => any;
 
   /**
-   * Log method
-   * @param message
+   * Writes a line to the script run log in Metric Insights (informational).
+   *
+   * @param message Text to record.
    */
   log: (message: string) => void;
 
   /**
-   * Returns script result
+   * Sets the primary output/result value for this script run (payload consumed by the MI host).
    *
-   * @param message
+   * @param message Serializable result—structure depends on your script contract with MI.
    */
   result: (message: any) => void;
 
   /**
-   * Error log method
-   * @param error
+   * Records an error for this script run (user-visible failure path in MI).
+   *
+   * @param error Error message or diagnostic text.
    */
   error: (error: string) => void;
 
   /**
-   * Finish script execution
+   * Ends script execution and releases host resources. Call when your async work is finished.
    */
   close: () => void;
 };
 
+/**
+ * Global injected by the Metric Insights custom script runtime. Prefer the exported {@link cs} alias in modules.
+ *
+ * @see {@link CustomScript}
+ */
 declare var customScript: CustomScript;
 
+/**
+ * Convenient alias for the global {@link customScript} object (`customScript` and `cs` refer to the same instance).
+ *
+ * @see {@link CustomScript}
+ */
 export const cs = customScript;
 
+/**
+ * Resolves script parameters by merging runtime values from {@link CustomScript.parameters | `cs.parameters`}
+ * with your defaults. Later sources win: values supplied in the Metric Insights UI (or host) override the same keys
+ * in `defaultParams`.
+ *
+ * The merged object is assigned to {@link CustomScript.parsedParams | `cs.parsedParams`} (and the same property on
+ * `globalThis` or `self` when present) so other code can read the resolved parameters without calling this function again.
+ *
+ * When you build with the cs-helper CLI, each `parseParams` call in your sources is analyzed: the generic type
+ * parameter (or the inferred default object shape) drives the parameter table, descriptions, and the **Params Base64**
+ * block in the output banner (base64-encoded JSON metadata for tooling).
+ *
+ * @template T Parameter map: keys are names; values must be `string`, `number`, or `boolean` (Metric Insights
+ *   parameter values are scalar).
+ * @param defaultParams Default values for parameters when the host does not supply them. May be a partial map.
+ * @returns The merged parameter object (`defaultParams` ⊕ `cs.parameters`).
+ */
 export function parseParams<
   T extends {
     [K in keyof T]: T[K] extends string | number | boolean ? T[K] : never;
@@ -69,4 +155,9 @@ export function parseParams<
   return params;
 }
 
+/**
+ * Secondary entry: logging, dataset/metadata helpers, and other utilities.
+ *
+ * Import as `import { … } from '@metricinsights/cs-helper/utils'` (or via namespace `utils` if your bundler resolves it).
+ */
 export * as utils from './utils';

--- a/src/polyfill/index-TARGET_EXTENSION.ts
+++ b/src/polyfill/index-TARGET_EXTENSION.ts
@@ -1,0 +1,5 @@
+/**
+ * `bin/build.ts` rewrites this import to `./index-v6` or `./index-v7` when bundling.
+ * This file exists so `tsc` can typecheck `index.ts` without that replacement.
+ */
+import './index-v6';

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -1,4 +1,14 @@
-// Declare global customScript to avoid circular dependency with main index
+/**
+ * Logging for custom scripts. Output goes through the host `customScript` API so this
+ * module does not import the main bundle (avoids circular dependencies).
+ *
+ * **Levels** (lowest to highest severity): `debug` (0) → `info` (1) → `warn` (2) →
+ * `error` (3) → `emergency` (4). `silent` (10) suppresses normal messages. Each level
+ * has a string name and a numeric string alias (e.g. `'1'` for info).
+ *
+ * **Batching**: {@link log} coalesces lines and flushes on a short timer, when the queue
+ * fills, or when the level changes. {@link error} always calls `customScript.error` immediately.
+ */
 declare var customScript: {
   log: (message: string) => void;
   error: (error: string) => void;
@@ -17,6 +27,7 @@ export const LOG_LEVEL_EMERGENCY_NUM = '4';
 export const LOG_LEVEL_SILENT = 'silent';
 export const LOG_LEVEL_SILENT_NUM = '10';
 
+/** Named log level accepted by {@link parseLogLevel} and {@link setLogLevel}. */
 export type LogLevel =
   | typeof LOG_LEVEL_DEBUG
   | typeof LOG_LEVEL_INFO
@@ -25,6 +36,7 @@ export type LogLevel =
   | typeof LOG_LEVEL_EMERGENCY
   | typeof LOG_LEVEL_SILENT;
 
+/** Stringified level number (`'0'`–`'4'`, `'10'`) accepted by {@link parseLogLevel}. */
 export type LogLevelNum =
   | typeof LOG_LEVEL_DEBUG_NUM
   | typeof LOG_LEVEL_INFO_NUM
@@ -33,6 +45,10 @@ export type LogLevelNum =
   | typeof LOG_LEVEL_EMERGENCY_NUM
   | typeof LOG_LEVEL_SILENT_NUM;
 
+/**
+ * Maps a level name, numeric string, or other string to the internal numeric severity.
+ * Unknown values default to **info** (1).
+ */
 export function parseLogLevel(level: LogLevel | LogLevelNum | string): number {
   switch (level) {
     case LOG_LEVEL_DEBUG:
@@ -64,7 +80,7 @@ export function parseLogLevel(level: LogLevel | LogLevelNum | string): number {
   }
 }
 
-// Internal log level state (defaults to INFO)
+/** Current minimum level to record; messages below this are dropped. Defaults to info. */
 let logLevel: number = parseLogLevel(LOG_LEVEL_INFO);
 
 /**
@@ -94,11 +110,12 @@ interface LogQueueItem {
 }
 
 const logQueue: LogQueueItem[] = [];
-let queueTimer: NodeJS.Timeout | null = null;
+let queueTimer: ReturnType<typeof setTimeout> | null = null;
 const QUEUE_BATCH_TIME = 200; // Reduced from 500ms to 200ms for faster processing
 const MAX_QUEUE_SIZE = 20; // Increased from 10 to 20 for better batching
 let currentQueueLevel: number | null = null;
 
+/** Sends queued lines as one `customScript.log` call and clears the queue. */
 function flushLogQueue() {
   if (logQueue.length === 0) {
     return;
@@ -121,6 +138,7 @@ function flushLogQueue() {
   }
 }
 
+/** Appends a line; may flush first if the new level differs from queued messages. */
 function addToQueue(message: string, level: number) {
   // If queue has different level, flush existing messages
   if (currentQueueLevel !== null && currentQueueLevel !== level) {
@@ -153,6 +171,13 @@ function addToQueue(message: string, level: number) {
   }, QUEUE_BATCH_TIME);
 }
 
+/**
+ * Queues a message if its level is at or above {@link getLogLevel}. Levels above
+ * **warn** are clamped to warn for this path (use {@link error} for errors).
+ *
+ * When {@link log.PERFORMANCE} is true, each flushed batch appends timing since
+ * {@link log.startTime} was last read (ms, integer).
+ */
 export function log(
   message: string,
   level: number | string | LogLevel | LogLevelNum,
@@ -170,13 +195,32 @@ export function log(
   }
 }
 
+/** Baseline for {@link log} performance suffixes; updated when timing is read. */
 log.startTime = performance.now();
+/** When true, batched log output includes `+<n>ms` since the previous batch. */
 log.PERFORMANCE = false;
 
+/**
+ * Sets the performance mode for the logging system
+ * @param performance - Whether to enable performance mode
+ */
+export function setLogPerformance(performance: boolean) {
+  log.PERFORMANCE = performance;
+
+  if (performance) {
+    log.startTime = Date.now();
+  }
+}
+
+/** Milliseconds since last `startTime` tick (used when `PERFORMANCE` is on). */
 function getLogTime() {
   return (-log.startTime + (log.startTime = performance.now())) >> 0;
 }
 
+/**
+ * Reports a problem via `customScript.error` when the configured level allows **error**,
+ * or when `emergency` is true and the level allows **emergency**. Not batched.
+ */
 export function error(message: string, emergency?: boolean) {
   if (
     parseLogLevel(LOG_LEVEL_ERROR) >= logLevel ||

--- a/test/scaffold.spec.mjs
+++ b/test/scaffold.spec.mjs
@@ -1,0 +1,242 @@
+import { test, expect } from '@playwright/test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+
+function runNpmSync(args, options) {
+  const npmExec = process.env.npm_execpath;
+
+  if (npmExec) {
+    return spawnSync(process.execPath, [npmExec, ...args], options);
+  }
+
+  return spawnSync('npm', args, {
+    shell: process.platform === 'win32',
+    ...options,
+  });
+}
+
+function scaffoldProject({ targetDir, template, packageName, description, version, v7, ai = [] }) {
+  const args = [
+    path.join('dist', 'bin', 'create.js'),
+    targetDir,
+    '--template',
+    template,
+    '--name',
+    packageName,
+    '--description',
+    description,
+    '--version',
+    version,
+  ];
+
+  if (v7) {
+    args.push('--v7');
+  }
+
+  for (const addon of ai) {
+    args.push('--ai', addon);
+  }
+
+  return spawnSync(process.execPath, args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    input: `${v7 ? 'y' : 'n'}\n`,
+  });
+}
+
+function runNpmCreateFromLocalPackage({ targetDir, template, packageName }) {
+  const pkgUrl = pathToFileURL(repoRoot).href;
+  const args = [
+    'exec',
+    '--yes',
+    `--package=${pkgUrl}`,
+    '--',
+    'cs-helper-create',
+    targetDir,
+    '--template',
+    template,
+    '--name',
+    packageName,
+    '--description',
+    `Scaffolded package ${packageName}`,
+    '--version',
+    '1.0.0',
+  ];
+
+  return runNpmSync(args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    input: 'n\n',
+  });
+}
+
+test.describe('project scaffold', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test.beforeAll(() => {
+    const build = runNpmSync(['run', 'build:bin'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    });
+
+    expect(build.status, `build:bin stderr: ${build.stderr}\nstdout: ${build.stdout}`).toBe(0);
+  });
+
+  test('loads project metadata', async () => {
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.resolve(repoRoot, 'package.json'), 'utf8'),
+    );
+
+    expect(packageJson.name).toBe('@metricinsights/cs-helper');
+  });
+
+  const scaffoldVariants = [
+    { template: 'custom-script-js', ext: 'js', v7: false },
+    { template: 'custom-script-js', ext: 'js', v7: true },
+    { template: 'custom-script-ts', ext: 'ts', v7: false },
+    { template: 'custom-script-ts', ext: 'ts', v7: true },
+  ];
+
+  for (const variant of scaffoldVariants) {
+    test(`scaffold + install for ${variant.template} (v7=${String(variant.v7)})`, async () => {
+      test.setTimeout(300_000);
+
+      const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cs-helper-scaffold-'));
+      const packageName = `${variant.template}-${variant.v7 ? 'v7' : 'v6'}-${Date.now()}`;
+      const targetDir = path.join(tmpRoot, packageName);
+
+      const scaffold = scaffoldProject({
+        targetDir,
+        template: variant.template,
+        packageName,
+        description: `Scaffolded package ${packageName}`,
+        version: '1.0.0',
+        v7: variant.v7,
+      });
+
+      try {
+        expect(scaffold.status, `scaffold stderr: ${scaffold.stderr}\nstdout: ${scaffold.stdout}`).toBe(0);
+
+        const packageJsonPath = path.join(targetDir, 'package.json');
+        const entryFilePath = path.join(targetDir, 'src', `${packageName}.${variant.ext}`);
+
+        expect(fs.existsSync(packageJsonPath)).toBeTruthy();
+        expect(fs.existsSync(entryFilePath)).toBeTruthy();
+
+        const generatedPackageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+        const buildScript = generatedPackageJson.scripts?.build ?? '';
+
+        expect(generatedPackageJson.name).toBe(packageName);
+        expect(buildScript.includes('--v7')).toBe(variant.v7);
+
+        const install = runNpmSync(['install', '--no-audit', '--fund=false'], {
+          cwd: targetDir,
+          encoding: 'utf8',
+        });
+
+        expect(install.status, `npm install stderr: ${install.stderr}\nstdout: ${install.stdout}`).toBe(0);
+        expect(fs.existsSync(path.join(targetDir, 'node_modules'))).toBeTruthy();
+        expect(
+          fs.existsSync(
+            path.join(targetDir, 'node_modules', '@metricinsights', 'cs-helper'),
+          ),
+        ).toBeTruthy();
+      } finally {
+        fs.rmSync(tmpRoot, { recursive: true, force: true });
+      }
+    });
+  }
+
+  for (const template of ['custom-script-js', 'custom-script-ts']) {
+    test(`npm create flow + install for ${template}`, async () => {
+      test.setTimeout(300_000);
+
+      const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cs-helper-npm-flow-'));
+      const packageName = `npm-flow-${template}-${Date.now()}`;
+      const targetDir = path.join(tmpRoot, packageName);
+
+      const createRun = runNpmCreateFromLocalPackage({
+        targetDir,
+        template,
+        packageName,
+      });
+
+      try {
+        expect(createRun.status, `create stderr: ${createRun.stderr}\nstdout: ${createRun.stdout}`).toBe(0);
+
+        const install = runNpmSync(['install', '--no-audit', '--fund=false'], {
+          cwd: targetDir,
+          encoding: 'utf8',
+        });
+
+        expect(install.status, `npm install stderr: ${install.stderr}\nstdout: ${install.stdout}`).toBe(0);
+        expect(fs.existsSync(path.join(targetDir, 'node_modules'))).toBeTruthy();
+      } finally {
+        fs.rmSync(tmpRoot, { recursive: true, force: true });
+      }
+    });
+  }
+
+  const aiAddonVariants = [
+    {
+      addons: ['cursor'],
+      expectedFiles: ['.cursor/rules/metric-insights-custom-script.mdc'],
+    },
+    {
+      addons: ['claude'],
+      expectedFiles: ['CLAUDE.md'],
+    },
+    {
+      addons: ['cursor', 'claude'],
+      expectedFiles: ['.cursor/rules/metric-insights-custom-script.mdc', 'CLAUDE.md'],
+    },
+  ];
+
+  for (const variant of aiAddonVariants) {
+    test(`scaffold + install with AI add-ons: ${variant.addons.join(',')}`, async () => {
+      test.setTimeout(300_000);
+
+      const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cs-helper-ai-addons-'));
+      const packageName = `ai-${variant.addons.join('-')}-${Date.now()}`;
+      const targetDir = path.join(tmpRoot, packageName);
+
+      const scaffold = scaffoldProject({
+        targetDir,
+        template: 'custom-script-ts',
+        packageName,
+        description: `AI scaffold ${packageName}`,
+        version: '1.0.0',
+        v7: false,
+        ai: variant.addons,
+      });
+
+      try {
+        expect(scaffold.status, `scaffold stderr: ${scaffold.stderr}\nstdout: ${scaffold.stdout}`).toBe(0);
+
+        for (const relativePath of variant.expectedFiles) {
+          expect(
+            fs.existsSync(path.join(targetDir, ...relativePath.split('/'))),
+            `Expected ${relativePath} to exist`,
+          ).toBeTruthy();
+        }
+
+        const install = runNpmSync(['install', '--no-audit', '--fund=false'], {
+          cwd: targetDir,
+          encoding: 'utf8',
+        });
+
+        expect(install.status, `npm install stderr: ${install.stderr}\nstdout: ${install.stdout}`).toBe(0);
+        expect(fs.existsSync(path.join(targetDir, 'node_modules'))).toBeTruthy();
+      } finally {
+        fs.rmSync(tmpRoot, { recursive: true, force: true });
+      }
+    });
+  }
+});

--- a/tsconfig.bin.json
+++ b/tsconfig.bin.json
@@ -1,10 +1,12 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "ignoreDeprecations": "6.0",
     "lib": ["esnext"],
     "module": "commonjs",
     "moduleResolution": "node",
     "removeComments": true,
+    "rootDir": "./bin",
     "sourceMap": true,
     "strict": true,
     "target": "esnext",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,12 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "ignoreDeprecations": "6.0",
     "lib": ["es2015", "dom"],
     "module": "es2015",
     "moduleResolution": "node",
     "removeComments": true,
+    "rootDir": "./src",
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,


### PR DESCRIPTION
## ai-100: Tooling, AI add-ons for scaffold, API docs, and Playwright tests

### Summary

This branch upgrades the build toolchain (TypeScript 6, explicit `rootDir`), adds optional **AI assistant add-ons** to `cs-helper-create` (`--ai` / interactive multiselect), expands **`CustomScript`** typing and logging utilities, introduces **Playwright** scaffold integration tests (including npm-exec flows and AI add-on files), runs **`npm test` in release CI**, documents **`parseParams`** and API usage in the README, and adds a **postbuild** step that copies the latest packed tarball to a `*-latest.tgz` name.

### Key changes

- **Build / deps:** `rootDir` and `ignoreDeprecations` in tsconfigs; polyfill `index-TARGET_EXTENSION.ts` for typecheck; TypeScript 6, webpack/prettier bumps; `postbuild` runs `npm pack` then `scripts/postbuild.js` for a stable `latest` tarball name.
- **Create CLI:** Optional copy from `ai-addons/<tool>/` into new projects with placeholder substitution; `--ai` (repeatable) when add-ons exist; TTY multiselect when stdin is interactive.
- **Published add-ons:** `ai-addons` for Claude (`CLAUDE.md`) and Cursor (rules `.mdc`); `package.json` `files` includes `ai-addons`.
- **API / types:** `CustomScript` JSDoc, `constants` shape, and related docs; `log.ts` documentation, `ReturnType<typeof setTimeout>` for portability, and `setLogPerformance`.
- **Tests:** Playwright config and `test/scaffold.spec.mjs` (scaffold variants, `npm exec` flow, AI add-on file assertions); `.gitignore` for `test-results`.
- **CI:** Release and release-beta workflows run `npm test` after build verification.
- **Docs:** README updates for AI add-ons, `parseParams`, `runApiRequest` / `homeSite` URL example.

### Included commits

```
90a8b1e docs: expand README for AI add-ons, parseParams, and API usage
421e41b ci: run npm test in release workflows
8dc6533 test: add Playwright scaffold integration tests
6b68353 feat(api): expand CustomScript type and logging utilities
abc0290 feat(create): optional ai-addons copy and --ai flag
413ed8d chore: add postbuild tarball copy, Playwright, and TypeScript 6 deps
a151974 build(tsconfig): add rootDir, ignoreDeprecations, and polyfill stub
49ba5c4 Merge pull request #25 from mi-examples/develop
```

### Testing

- `npm test` (Playwright): scaffold + install for JS/TS templates (v6/v7), `npm exec` create flow, and AI add-on (`cursor`, `claude`, both) scenarios.