### PR TITLE
develop → main: 0.7.0-beta.2, scaffold CI fix, and log parameter rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# [0.7.0-beta.2](https://github.com/mi-examples/cs-helper/compare/v0.7.0-beta.1...v0.7.0-beta.2) (2026-04-14)
+
+
+### Bug Fixes
+
+* **log:** rename setLogPerformance param to avoid shadowing performance ([8e63342](https://github.com/mi-examples/cs-helper/commit/8e6334288c7c68fa94af0cf2970e62f1ab350dc0))
+* **test:** install scaffold from local cs-helper pack tarball ([3007b9d](https://github.com/mi-examples/cs-helper/commit/3007b9d1f97d6a1b7082b3a497097e8a87043095))
+
 # [0.7.0-beta.1](https://github.com/mi-examples/cs-helper/compare/v0.6.4...v0.7.0-beta.1) (2026-04-14)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [0.7.0-beta.3](https://github.com/mi-examples/cs-helper/compare/v0.7.0-beta.2...v0.7.0-beta.3) (2026-04-14)
+
+
+### Bug Fixes
+
+* **log:** use performance.now when enabling performance mode ([41c9bb0](https://github.com/mi-examples/cs-helper/commit/41c9bb0cce7b2ed70831c88057629e09b6858ed1))
+
 # [0.7.0-beta.2](https://github.com/mi-examples/cs-helper/compare/v0.7.0-beta.1...v0.7.0-beta.2) (2026-04-14)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@metricinsights/cs-helper",
-  "version": "0.7.0-beta.1",
+  "version": "0.7.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@metricinsights/cs-helper",
-      "version": "0.7.0-beta.1",
+      "version": "0.7.0-beta.2",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@metricinsights/cs-helper",
-  "version": "0.7.0-beta.2",
+  "version": "0.7.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@metricinsights/cs-helper",
-      "version": "0.7.0-beta.2",
+      "version": "0.7.0-beta.3",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metricinsights/cs-helper",
-  "version": "0.7.0-beta.1",
+  "version": "0.7.0-beta.2",
   "description": "Helper for Custom Scripts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metricinsights/cs-helper",
-  "version": "0.7.0-beta.2",
+  "version": "0.7.0-beta.3",
   "description": "Helper for Custom Scripts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -202,12 +202,12 @@ log.PERFORMANCE = false;
 
 /**
  * Sets the performance mode for the logging system
- * @param performance - Whether to enable performance mode
+ * @param usePerformance - Whether to enable performance mode
  */
-export function setLogPerformance(performance: boolean) {
-  log.PERFORMANCE = performance;
+export function setLogPerformance(usePerformance: boolean) {
+  log.PERFORMANCE = usePerformance;
 
-  if (performance) {
+  if (usePerformance) {
     log.startTime = Date.now();
   }
 }

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -208,7 +208,7 @@ export function setLogPerformance(usePerformance: boolean) {
   log.PERFORMANCE = usePerformance;
 
   if (usePerformance) {
-    log.startTime = Date.now();
+    log.startTime = performance.now();
   }
 }
 

--- a/test/scaffold.spec.mjs
+++ b/test/scaffold.spec.mjs
@@ -9,6 +9,46 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, '..');
 
+/**
+ * Basename of the copied pack artifact from `scripts/postbuild.js` (e.g. `metricinsights-cs-helper-latest.tgz`).
+ * Scaffold templates depend on `^%PLUGIN_VERSION%` from npm; unreleased versions are not on the registry, so
+ * integration tests install from this local tarball instead (avoids ETARGET in CI).
+ */
+function getPackLatestBasename() {
+  const pkg = JSON.parse(
+    fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'),
+  );
+  const packName = pkg.name.replace(/^@/, '').replace(/\//g, '-');
+
+  return `${packName}-latest.tgz`;
+}
+
+/**
+ * Point the scaffolded project's `@metricinsights/cs-helper` dependency at the repo-root `*-latest.tgz`
+ * produced by `npm run postbuild`.
+ */
+function useLocalCsHelperPack(targetDir) {
+  const tgzBasename = getPackLatestBasename();
+  const tgzPath = path.join(repoRoot, tgzBasename);
+
+  if (!fs.existsSync(tgzPath)) {
+    throw new Error(
+      `Missing ${tgzBasename} at ${tgzPath}. Run "npm run postbuild" in the cs-helper repo first.`,
+    );
+  }
+
+  const relPosix = path
+    .relative(targetDir, tgzPath)
+    .split(path.sep)
+    .join('/');
+  const pkgPath = path.join(targetDir, 'package.json');
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+
+  pkg.dependencies = pkg.dependencies ?? {};
+  pkg.dependencies['@metricinsights/cs-helper'] = `file:${relPosix}`;
+  fs.writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+}
+
 function runNpmSync(args, options) {
   const npmExec = process.env.npm_execpath;
 
@@ -81,12 +121,28 @@ test.describe('project scaffold', () => {
   test.describe.configure({ mode: 'serial' });
 
   test.beforeAll(() => {
-    const build = runNpmSync(['run', 'build:bin'], {
+    const build = runNpmSync(['run', 'build'], {
       cwd: repoRoot,
       encoding: 'utf8',
     });
 
-    expect(build.status, `build:bin stderr: ${build.stderr}\nstdout: ${build.stdout}`).toBe(0);
+    expect(build.status, `build stderr: ${build.stderr}\nstdout: ${build.stdout}`).toBe(
+      0,
+    );
+
+    const postbuild = runNpmSync(['run', 'postbuild'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    });
+
+    expect(
+      postbuild.status,
+      `postbuild stderr: ${postbuild.stderr}\nstdout: ${postbuild.stdout}`,
+    ).toBe(0);
+    expect(
+      fs.existsSync(path.join(repoRoot, getPackLatestBasename())),
+      `expected ${getPackLatestBasename()} after postbuild`,
+    ).toBeTruthy();
   });
 
   test('loads project metadata', async () => {
@@ -136,6 +192,8 @@ test.describe('project scaffold', () => {
         expect(generatedPackageJson.name).toBe(packageName);
         expect(buildScript.includes('--v7')).toBe(variant.v7);
 
+        useLocalCsHelperPack(targetDir);
+
         const install = runNpmSync(['install', '--no-audit', '--fund=false'], {
           cwd: targetDir,
           encoding: 'utf8',
@@ -170,6 +228,8 @@ test.describe('project scaffold', () => {
 
       try {
         expect(createRun.status, `create stderr: ${createRun.stderr}\nstdout: ${createRun.stdout}`).toBe(0);
+
+        useLocalCsHelperPack(targetDir);
 
         const install = runNpmSync(['install', '--no-audit', '--fund=false'], {
           cwd: targetDir,
@@ -226,6 +286,8 @@ test.describe('project scaffold', () => {
             `Expected ${relativePath} to exist`,
           ).toBeTruthy();
         }
+
+        useLocalCsHelperPack(targetDir);
 
         const install = runNpmSync(['install', '--no-audit', '--fund=false'], {
           cwd: targetDir,


### PR DESCRIPTION
## develop → main: 0.7.0-beta.2, scaffold CI fix, and log parameter rename

### Summary

Merges **`develop`** into **`main`** to ship **0.7.0-beta.2** (changelog and version bump on `develop`), including **PR #28** (**ai-100**): scaffold tests install **`@metricinsights/cs-helper`** from the local **`metricinsights-cs-helper-latest.tgz`** after **`npm run postbuild`**, avoiding **`ETARGET`** in release CI when the version is not yet on npm; plus a small **`setLogPerformance`** parameter rename so it does not shadow the global **`performance`** object.

### Key changes

- **Version / changelog:** `0.7.0-beta.2` on `develop`.
- **Tests:** `test/scaffold.spec.mjs` — `beforeAll` runs full **`build`** + **`postbuild`**; **`useLocalCsHelperPack`** sets `file:` dependency before **`npm install`** in all scaffold paths.
- **API:** `setLogPerformance(usePerformance)` in **`src/utils/log.ts`**.
- **Lockfile:** Bumped with the release version where applicable.

### Included commits

```
a6de40a chore(release): 0.7.0-beta.2 [skip ci]
927806f Merge pull request #28 from mi-examples/ai-100
8e63342 fix(log): rename setLogPerformance param to avoid shadowing performance
3007b9d fix(test): install scaffold from local cs-helper pack tarball
```

### Testing

- `npm test` (Playwright) on `develop` after these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release v0.7.0-beta.3

* **Bug Fixes**
  * Improved logging accuracy by switching to high-resolution timing when performance mode is enabled.
  * Continued fixes to test/scaffold flows to ensure local package-based installs work reliably.

* **Chores**
  * Package version updated to 0.7.0-beta.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->