### PR TITLE
fix(log): use performance.now when enabling performance mode

### DIFF
--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -208,7 +208,7 @@ export function setLogPerformance(usePerformance: boolean) {
   log.PERFORMANCE = usePerformance;
 
   if (usePerformance) {
-    log.startTime = Date.now();
+    log.startTime = performance.now();
   }
 }
 


### PR DESCRIPTION
setLogPerformance reset startTime with Date.now while batched log timing uses performance.now(), mixing clocks and skewing +<n>ms suffixes.