### PR TITLE
AI-100 chore: update MI API guidance and dependency baselines

### DIFF
--- a/ai-addons/claude/CLAUDE.md
+++ b/ai-addons/claude/CLAUDE.md
@@ -38,6 +38,11 @@ For failures, use **`cs.error(...)`** (and **`cs.result(...)`** / **`cs.close()`
 
 **Use `cs.runApiRequest(url, settings?)` (or `customScript.runApiRequest`) for all Metric Insights backend HTTP calls.** Do not use raw `fetch`, `XMLHttpRequest`, or manual AJAX for normal API access unless you have a rare, documented exception.
 
+### Official MI API docs (partial coverage)
+
+- Primary docs: **https://help.metricinsights.com/m/API_Access**
+- Coverage is **not complete**. Some endpoints/fields/edge-case behaviors may be undocumented; confirm with runtime API responses, your MI instance behavior, and release notes/support when needed.
+
 ### Authentication
 
 Metric Insights injects API authentication for you. Each request includes an HTTP header:

--- a/ai-addons/cursor/.cursor/rules/metric-insights-custom-script.mdc
+++ b/ai-addons/cursor/.cursor/rules/metric-insights-custom-script.mdc
@@ -23,6 +23,11 @@ Scaffolded with `cs-helper`. Build: `npm run build` → `dist/`. The build scrip
 
 **Use `cs.runApiRequest(url, settings?)` for every MI backend HTTP call** (not raw `fetch` / XHR by default).
 
+### Official MI API docs (partial)
+
+- Primary reference: **https://help.metricinsights.com/m/API_Access**
+- Treat this documentation as **incomplete**. Some endpoints, behavior details, and version-specific quirks may be missing. Validate with runtime responses and MI support/release notes when implementation details are unclear.
+
 - **Auth:** MI injects header **`token`:** same value as **`cs.apiToken`**. Do not set it manually for normal API use.
 - **Token TTL:** Server-configured; often **≥ ~5 minutes** in typical setups, but **verify** your policy. Long-running scripts should implement **refresh**: **`GET`** **`/api/get_token`** → JSON **`{ token: string; expires: string }`**, then continue API calls with refreshed credentials per your MI version (schedule using **`expires`**).
 - **Stack:** Wrapper over **jQuery.ajax** — **jQuery 1.2.x** on v6 (PhantomJS), **jQuery 3.x** on v7 (Puppeteer). **`settings`** = jQuery ajax options (`success`, `error`, `type`, `data`, …).

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,8 +21,8 @@
         "prompts": "^2.4.2",
         "string-includes-polyfill": "^1.0.6",
         "ts-loader": "^9.5.7",
-        "typescript": "^6.0.2",
-        "webpack": "^5.106.1"
+        "typescript": "^6.0.3",
+        "webpack": "^5.106.2"
       },
       "bin": {
         "cs-helper": "dist/bin/build.js",
@@ -37,7 +37,7 @@
         "@types/prompts": "^2.4.9",
         "brace-expansion": "5.0.5",
         "picomatch": "4.0.4",
-        "prettier": "^3.8.2",
+        "prettier": "^3.8.3",
         "semantic-release": "^25.0.3"
       }
     },
@@ -4639,6 +4639,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
@@ -4944,22 +4945,10 @@
       }
     },
     "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
       "engines": {
         "node": ">= 0.6"
       }
@@ -7407,9 +7396,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.2.tgz",
-      "integrity": "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -8706,9 +8695,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -8923,9 +8912,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/webpack": {
-      "version": "5.106.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.1.tgz",
-      "integrity": "sha512-EW8af29ak8Oaf4T8k8YsajjrDBDYgnKZ5er6ljWFJsXABfTNowQfvHLftwcepVgdz+IoLSdEAbBiM9DFXoll9w==",
+      "version": "5.106.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.2.tgz",
+      "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
       "license": "MIT",
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
@@ -8944,9 +8933,8 @@
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.11",
-        "json-parse-even-better-errors": "^2.3.1",
         "loader-runner": "^4.3.1",
-        "mime-types": "^2.1.27",
+        "mime-db": "^1.54.0",
         "neo-async": "^2.6.2",
         "schema-utils": "^4.3.3",
         "tapable": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@types/prompts": "^2.4.9",
     "brace-expansion": "5.0.5",
     "picomatch": "4.0.4",
-    "prettier": "^3.8.2",
+    "prettier": "^3.8.3",
     "semantic-release": "^25.0.3"
   },
   "dependencies": {
@@ -99,8 +99,8 @@
     "prompts": "^2.4.2",
     "string-includes-polyfill": "^1.0.6",
     "ts-loader": "^9.5.7",
-    "typescript": "^6.0.2",
-    "webpack": "^5.106.1"
+    "typescript": "^6.0.3",
+    "webpack": "^5.106.2"
   },
   "bugs": {
     "url": "https://github.com/mi-examples/cs-helper/issues"

--- a/templates/custom-script-js/package.json
+++ b/templates/custom-script-js/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "prettier": "^3.8.1"
+    "prettier": "^3.8.3"
   },
   "dependencies": {
     "@metricinsights/cs-helper": "^%PLUGIN_VERSION%"

--- a/templates/custom-script-ts/package.json
+++ b/templates/custom-script-ts/package.json
@@ -12,8 +12,8 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "prettier": "^3.8.1",
-    "typescript": "^5.9.3"
+    "prettier": "^3.8.3",
+    "typescript": "^6.0.3"
   },
   "dependencies": {
     "@metricinsights/cs-helper": "^%PLUGIN_VERSION%"


### PR DESCRIPTION
## Title
chore: update MI API guidance and dependency baselines

## Summary
This PR updates AI assistant guidance with official Metric Insights API documentation references and clarifies that API coverage is partial/incomplete.
It also upgrades dependency baselines in the root package and templates to keep scaffolded projects current.

## Key changes
- Add official MI API Access docs link to `ai-addons/cursor/.cursor/rules/metric-insights-custom-script.mdc` and `ai-addons/claude/CLAUDE.md`.
- Explicitly note that MI API documentation is partial, and recommend validating behavior against runtime responses and release notes/support.
- Bump root dependencies: `prettier` to `^3.8.3`, `typescript` to `^6.0.3`, `webpack` to `^5.106.2`.
- Update template dependency baselines:
  - `templates/custom-script-js/package.json`: `prettier` to `^3.8.3`
  - `templates/custom-script-ts/package.json`: `prettier` to `^3.8.3`, `typescript` to `^6.0.3`
- Refresh `package-lock.json` after dependency updates.

## Included commits
- `d068d44` chore: update MI API guidance and dependency baselines
- `c95e494` Merge pull request #29 from mi-examples/develop
- `cc6600d` Merge pull request #27 from mi-examples/develop

## Diff stat
- 6 files changed, 33 insertions(+), 35 deletions(-)

## Testing
- `npm audit --json` (root): 0 vulnerabilities
- `npm test -- test/scaffold.spec.mjs`: 10 passed