### PR TITLE
Release: npm trusted publishing and audit hardening

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write # npm trusted publisher (OIDC)
 
 jobs:
   release:
@@ -20,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org/
           cache: 'npm'
 
@@ -53,7 +54,7 @@ jobs:
 
       - name: Publish to npm
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ''
         run: npm publish --access public
 
       - name: Create GitHub Release

--- a/README.md
+++ b/README.md
@@ -354,3 +354,22 @@ This is my custom script description...
 
 ***** --------- *****
 ```
+
+## Maintainers: publishing to npm
+
+Production releases publish from [`.github/workflows/release.yml`](.github/workflows/release.yml) when a `v*` tag is pushed. Authentication uses [npm trusted publishing](https://docs.npmjs.com/trusted-publishers/) (OIDC from GitHub Actions), not a long-lived `NPM_TOKEN`.
+
+### One-time setup on npmjs.com
+
+1. Open **@metricinsights/cs-helper** → **Settings** → **Trusted Publisher**.
+2. Choose **GitHub Actions** and configure:
+   - **Organization or user**: `mi-examples`
+   - **Repository**: `cs-helper`
+   - **Workflow filename**: `release.yml` (exact name, including `.yml`)
+3. After the first successful OIDC publish, consider **Publishing access** → **Require two-factor authentication and disallow tokens**, then revoke the old automation token from npm account settings.
+
+### Requirements
+
+- GitHub-hosted runners (self-hosted runners are not supported for trusted publishing).
+- Node.js **24** in the release workflow (npm ≥ 11.5.1 for OIDC).
+- `repository.url` in `package.json` must match `https://github.com/mi-examples/cs-helper`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,8 @@
         "@types/jquery": "^3.5.34",
         "@types/promise-polyfill": "^6.0.6",
         "@types/prompts": "^2.4.9",
-        "brace-expansion": "5.0.5",
+        "brace-expansion": "^5.0.6",
+        "ip-address": "^10.2.0",
         "picomatch": "4.0.4",
         "prettier": "^3.8.3",
         "semantic-release": "^25.0.3"
@@ -984,9 +985,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-      "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.28.6",
@@ -2974,9 +2975,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3950,9 +3951,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -4423,6 +4424,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/is-arrayish": {
@@ -5672,7 +5683,7 @@
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
-      "version": "5.0.5",
+      "version": "5.0.6",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5964,7 +5975,7 @@
       }
     },
     "node_modules/npm/node_modules/ip-address": {
-      "version": "10.1.0",
+      "version": "10.2.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
     "@types/jquery": "^3.5.34",
     "@types/promise-polyfill": "^6.0.6",
     "@types/prompts": "^2.4.9",
-    "brace-expansion": "5.0.5",
+    "brace-expansion": "^5.0.6",
+    "ip-address": "^10.2.0",
     "picomatch": "4.0.4",
     "prettier": "^3.8.3",
     "semantic-release": "^25.0.3"

--- a/scripts/sync-npm-bundled-patches.js
+++ b/scripts/sync-npm-bundled-patches.js
@@ -2,9 +2,9 @@
 
 /**
  * The `npm` package (pulled in by @semantic-release/npm) ships vulnerable
- * bundled copies of brace-expansion and picomatch. Overrides do not replace
- * bundleDependencies. After install, copy patched versions from the hoisted
- * tree into npm's nested node_modules so `npm audit` is clean.
+ * bundled copies of brace-expansion, picomatch, and ip-address. Overrides do
+ * not replace bundleDependencies. After install, copy patched versions from the
+ * hoisted tree into npm's nested node_modules so `npm audit` is clean.
  */
 const fs = require('fs');
 const path = require('path');
@@ -31,6 +31,26 @@ function findNpmInstallDir(startDir) {
   }
 }
 
+function readPackageVersion(packageDir) {
+  return JSON.parse(
+    fs.readFileSync(path.join(packageDir, 'package.json'), 'utf8'),
+  ).version;
+}
+
+function replaceBundledPackage(npmDir, packageName, srcDir) {
+  const dest = path.join(npmDir, 'node_modules', packageName);
+  const destParent = path.dirname(dest);
+
+  if (!fs.existsSync(destParent)) {
+    return null;
+  }
+
+  fs.rmSync(dest, { recursive: true, force: true });
+  fs.cpSync(srcDir, dest, { recursive: true });
+
+  return readPackageVersion(srcDir);
+}
+
 function main() {
   const npmDir = findNpmInstallDir(packageRoot);
 
@@ -40,6 +60,7 @@ function main() {
 
   let braceSrc;
   let picomatchSrc;
+  let ipAddressSrc;
 
   try {
     braceSrc = path.dirname(
@@ -48,15 +69,22 @@ function main() {
     picomatchSrc = path.dirname(
       require.resolve('picomatch/package.json', { paths: [packageRoot] }),
     );
+    ipAddressSrc = path.dirname(
+      require.resolve('ip-address/package.json', { paths: [packageRoot] }),
+    );
   } catch {
     return;
   }
 
-  const braceDest = path.join(npmDir, 'node_modules', 'brace-expansion');
+  const versions = {};
 
-  if (fs.existsSync(path.dirname(braceDest))) {
-    fs.rmSync(braceDest, { recursive: true, force: true });
-    fs.cpSync(braceSrc, braceDest, { recursive: true });
+  const braceVersion = replaceBundledPackage(
+    npmDir,
+    'brace-expansion',
+    braceSrc,
+  );
+  if (braceVersion) {
+    versions.braceExpansion = braceVersion;
   }
 
   const picomatchParent = path.join(
@@ -70,20 +98,23 @@ function main() {
   if (fs.existsSync(picomatchParent)) {
     fs.rmSync(picomatchDest, { recursive: true, force: true });
     fs.cpSync(picomatchSrc, picomatchDest, { recursive: true });
+    versions.picomatch = readPackageVersion(picomatchSrc);
   }
 
-  const braceVersion = JSON.parse(
-    fs.readFileSync(path.join(braceSrc, 'package.json'), 'utf8'),
-  ).version;
-  const picomatchVersion = JSON.parse(
-    fs.readFileSync(path.join(picomatchSrc, 'package.json'), 'utf8'),
-  ).version;
+  const ipAddressVersion = replaceBundledPackage(
+    npmDir,
+    'ip-address',
+    ipAddressSrc,
+  );
+  if (ipAddressVersion) {
+    versions.ipAddress = ipAddressVersion;
+  }
 
-  patchPackageLock(packageRoot, braceVersion, picomatchVersion);
+  patchPackageLock(packageRoot, versions);
 }
 
 /** npm audit reads package-lock.json; align bundled entry versions with on-disk copies. */
-function patchPackageLock(root, braceVersion, picomatchVersion) {
+function patchPackageLock(root, versions) {
   const lockPath = path.join(root, 'package-lock.json');
 
   if (!fs.existsSync(lockPath)) {
@@ -98,22 +129,24 @@ function patchPackageLock(root, braceVersion, picomatchVersion) {
     return;
   }
 
-  const braceKey = 'node_modules/npm/node_modules/brace-expansion';
-  const picomatchKey =
-    'node_modules/npm/node_modules/tinyglobby/node_modules/picomatch';
+  const lockPatches = [
+    ['node_modules/npm/node_modules/brace-expansion', versions.braceExpansion],
+    [
+      'node_modules/npm/node_modules/tinyglobby/node_modules/picomatch',
+      versions.picomatch,
+    ],
+    ['node_modules/npm/node_modules/ip-address', versions.ipAddress],
+  ];
 
   let changed = false;
 
-  if (pkgs[braceKey]) {
-    pkgs[braceKey].version = braceVersion;
-    changed = true;
+  for (const [key, version] of lockPatches) {
+    if (version && pkgs[key]) {
+      pkgs[key].version = version;
+      changed = true;
+    }
   }
 
-  if (pkgs[picomatchKey]) {
-    pkgs[picomatchKey].version = picomatchVersion;
-    changed = true;
-  }
-  
   if (changed) {
     fs.writeFileSync(lockPath, `${JSON.stringify(lock, null, 2)}\n`, 'utf8');
   }


### PR DESCRIPTION
# Release: npm trusted publishing and audit hardening

## Summary

Merges the latest `develop` changes into `main`, centered on **secure npm publishing** (OIDC trusted publisher instead of `NPM_TOKEN`) and a **clean `npm audit`** for maintainer dependencies.

This is an infrastructure and security release; no changes to the published package API or CLI behavior for consumers.

## Key changes

- **Production release workflow** (`.github/workflows/release.yml`):
  - GitHub Actions OIDC (`id-token: write`) for [npm trusted publishing](https://docs.npmjs.com/trusted-publishers/)
  - Node.js **24** (npm ≥ 11.5.1)
  - Removes `NPM_TOKEN`; uses empty `NODE_AUTH_TOKEN` at publish time so the CLI uses OIDC
- **Beta release workflow**: Node.js 24 aligned with production CI
- **Dependency / audit maintenance**:
  - `brace-expansion@5.0.6`, `ip-address@10.2.0`, lockfile updates (`fast-uri`, Babel plugin)
  - `scripts/sync-npm-bundled-patches.js` extended for bundled `ip-address` inside `npm`
- **Documentation**: README maintainer section for Trusted Publisher setup on npmjs.com

## Before / after first production tag on `main`

| Step | Action |
|------|--------|
| 1 | On npmjs.com → **@metricinsights/cs-helper** → **Trusted Publisher**: `mi-examples` / `cs-helper` / workflow `release.yml` |
| 2 | Push or create release tag `v*` (triggers `release.yml`) |
| 3 | After successful OIDC publish, optionally **disallow tokens** on npm and revoke legacy `NPM_TOKEN` (GitHub + npm) |

## Testing

- [x] `npm ci` + `npm audit` — 0 vulnerabilities (with postinstall sync)
- [x] `npm test` — Playwright scaffold suite (10 tests) passed on the feature branch
- [ ] Verify production publish on next `v*` tag after Trusted Publisher is configured

## Included commits

```
d4d75b2 Merge pull request #33 from mi-examples/pp-3443
ddf0bb1 ci(release): use npm trusted publisher and fix audit
```

## Files changed (`origin/main`...`origin/develop`)

```
 .github/workflows/release-beta.yml  |  2 +-
 .github/workflows/release.yml       |  5 ++-
 README.md                           | 19 +++++++++
 package-lock.json                   | 35 +++++++++------
 package.json                        |  3 +-
 scripts/sync-npm-bundled-patches.js | 85 +++++++++++++++++++++++++------------
 6 files changed, 107 insertions(+), 42 deletions(-)
```

**Merge Request:** `origin/develop` → `origin/main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js to version 24 in release workflows
  * Updated development dependency versions

* **Documentation**
  * Added maintainer documentation for npm publishing setup via GitHub Actions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mi-examples/cs-helper/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->