### PR TITLE
pp-3534: document script lifecycle (heartbeat, scriptTimeout, scaffolds)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,45 @@ const params = parseParams<{
 
 Only **`string`**, **`number`**, and **`boolean`** values are supported for parameter types (MI passes scalar values). At build time, the cs-helper CLI scans `parseParams` usage to generate the **Params Base64** banner block and the parameter tables in the [Build Output](#build-output) section—see **Params Base64** there for what is embedded.
 
+### Inactivity watchdog (`heartBeat` / `updateHeartBeat`)
+
+When you build with cs-helper, the bundled wrapper tracks script activity via **`cs.heartBeat`** and refreshes it automatically on successful **`cs.runApiRequest`**, on **`cs.log`**, and while waiting for a slow API response.
+
+If nothing refreshes the watchdog for too long (typically about **one minute**), Metric Insights ends the run as hung. Silent work does not count—tight loops, heavy computation, or long **`setTimeout`** chains without logging or API calls need an explicit **`cs.updateHeartBeat()`** every so often (for example once per loop iteration or every N seconds).
+
+```javascript
+for (let i = 0; i < items.length; i++) {
+  processItem(items[i]);
+  if (i % 100 === 0) {
+    cs.updateHeartBeat();
+  }
+}
+```
+
+### Finishing runs (`close`, `scriptTimeout`)
+
+Always end a run with **`cs.close()`** when work finishes (success or controlled failure). Schedule **`close`** inside a short **`setTimeout`** (for example **500–1000 ms**) so MI can flush **`cs.result`** and log lines first—see the scaffold templates for a **`scheduleClose()`** helper.
+
+Independently of the inactivity watchdog, keep a **maximum wall-clock limit** using a **`scriptTimeout`** parameter (**milliseconds**) and a safety timer started at load time. If **`main`** never completes, log and close:
+
+```javascript
+const params = parseParams({
+  scriptTimeout: 10 * 60 * 1000,
+});
+
+function scheduleClose() {
+  setTimeout(() => cs.close(), 1000);
+}
+
+setTimeout(() => {
+  if (cs.isClosed) return;
+  cs.log('Script exceeded scriptTimeout; closing.');
+  scheduleClose();
+}, params.scriptTimeout);
+```
+
+Tune **`scriptTimeout`** in Metric Insights per script; it should be longer than your expected happy path but short enough to avoid orphaned runs.
+
 ### Backend HTTP requests (`runApiRequest`)
 
 Use **`cs.runApiRequest(url, settings?)`** for Metric Insights backend APIs. The host injects API authentication and provides the transport layer. Build URLs from **`cs.homeSite`** (or **`customScript.homeSite`**) plus the API path—see the **Data convertor** example below.

--- a/ai-addons/claude/CLAUDE.md
+++ b/ai-addons/claude/CLAUDE.md
@@ -132,11 +132,18 @@ function buildRequest<T extends {} = any>(
 }
 ```
 
+## Inactivity watchdog (`heartBeat` / `updateHeartBeat`)
+
+The cs-helper build wrapper refreshes **`cs.heartBeat`** on successful **`runApiRequest`**, on **`log`**, and while waiting for slow API responses. If the watchdog is not refreshed for too long (typically **~1 minute**), Metric Insights ends the run.
+
+- Call **`cs.updateHeartBeat()`** in long stretches with **no** logging and **no** API traffic (tight loops, heavy CPU work, idle timer chains).
+- This is **independent** of **`scriptTimeout`** (wall-clock max run time).
+
 ## Finishing the script (`cs.close`)
 
 - The script must end by calling **`cs.close()`** when work is done (success or controlled failure).
 - **Best practice:** schedule **`cs.close()` inside `setTimeout(..., 500)`** (e.g. a small `scheduleClose()` helper) so Metric Insights can flush **`cs.result`** / logs before teardown.
-- **Safety timeout:** keep a **maximum execution window** by passing **`scriptTimeout`** in **milliseconds** (ms) from script parameters and using e.g. `setTimeout(..., scriptTimeout)` so that if the script never finishes normally, you **`cs.log`** and then call **`cs.close()`** (again after the usual short delay), avoiding stuck runs.
+- **Safety timeout:** declare **`scriptTimeout`** (**milliseconds**) in **`parseParams`** and register a **load-time** `setTimeout(..., scriptTimeout)` that checks **`cs.isClosed`**, **`cs.log`s** if the run overran, then **`scheduleClose()`**—see the scaffold **`src/index.ts`**. Tune the value per script in MI.
 
 ## Project metadata
 

--- a/ai-addons/cursor/.cursor/rules/metric-insights-custom-script.mdc
+++ b/ai-addons/cursor/.cursor/rules/metric-insights-custom-script.mdc
@@ -55,4 +55,11 @@ Use:
 - **`cs.log(...)`** from `@metricinsights/cs-helper`, or **`customScript.log(...)`**
 - **`import { log } from '@metricinsights/cs-helper/utils'`** for leveled logging (still goes through MI’s log path)
 
-Use **`cs.error`**, **`cs.result`**, and **`cs.close`** to finish. Always end runs with **`cs.close()`**; prefer wrapping it in **`setTimeout(..., 500)`** so MI can flush output. Use a **parameter-driven hang timeout**: read **`scriptTimeout`** (**milliseconds**) from script params and pass it to **`setTimeout`** so a stuck script **`cs.log`s** and then closes.
+Use **`cs.error`**, **`cs.result`**, and **`cs.close`** to finish. Always end runs with **`cs.close()`**; prefer wrapping it in **`setTimeout(..., 500)`** so MI can flush output. Use a **parameter-driven hang timeout**: read **`scriptTimeout`** (**milliseconds**) from script params and pass it to **`setTimeout`** so a stuck script **`cs.log`s** and then closes (guard with **`cs.isClosed`** before logging).
+
+## Inactivity watchdog (`heartBeat` / `updateHeartBeat`)
+
+The cs-helper build wrapper refreshes **`cs.heartBeat`** automatically on successful **`runApiRequest`**, on **`log`**, and during slow API waits. Without activity, the host typically ends the run after **~1 minute**.
+
+- **Long silent work** (CPU loops, batch processing without logging): call **`cs.updateHeartBeat()`** periodically.
+- **`scriptTimeout`** (ms) is a separate **wall-clock cap**—always register a load-time **`setTimeout(..., scriptTimeout)`** that logs and **`scheduleClose()`** if the script never finishes normally (see scaffold **`src/index.ts`**).

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
   "scripts": {
     "postinstall": "node scripts/sync-npm-bundled-patches.js",
     "prepare": "node scripts/sync-npm-bundled-patches.js",
-    "build": "npm run build:sources && npm run build:bin",
-    "postbuild": "npm pack && node scripts/postbuild.js",
+    "clean:dist": "node scripts/clean-dist.cjs",
+    "build": "npm run clean:dist && npm run build:sources && npm run build:bin",
+    "postbuild": "npm pack && node scripts/postbuild.mjs",
     "build:sources": "tsc",
     "build:bin": "tsc --project tsconfig.bin.json",
     "test": "playwright test",

--- a/scripts/clean-dist.cjs
+++ b/scripts/clean-dist.cjs
@@ -1,0 +1,8 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const distDir = path.join(__dirname, '..', 'dist');
+
+fs.rmSync(distDir, { recursive: true, force: true });

--- a/scripts/postbuild.mjs
+++ b/scripts/postbuild.mjs
@@ -5,11 +5,9 @@ import { fileURLToPath } from 'url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const rootDir = join(__dirname, '..');
 
-// Read package name from package.json
 const pkg = JSON.parse(readFileSync(join(rootDir, 'package.json'), 'utf8'));
 const packName = pkg.name.replace(/^@/, '').replace(/\//g, '-');
 
-// Find latest .tgz file matching the package
 const tgzFiles = readdirSync(rootDir)
   .filter((f) => f.endsWith('.tgz') && f.startsWith(packName))
   .map((f) => ({
@@ -26,9 +24,10 @@ if (tgzFiles.length === 0) {
 
 const latest = tgzFiles[0];
 const latestName = latest.name;
-
-// Replace version with "latest" in filename (e.g. pkg-1.0.0.tgz -> pkg-latest.tgz)
-const latestNameNew = latestName.replace(/-[\d.]+(-[a-z0-9.-]+)?\.tgz$/, '-latest.tgz');
+const latestNameNew = latestName.replace(
+  /-[\d.]+(-[a-z0-9.-]+)?\.tgz$/,
+  '-latest.tgz',
+);
 const destPath = join(rootDir, latestNameNew);
 
 copyFileSync(latest.path, destPath);

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,21 @@ type ParametersType = Record<string, string | number | boolean>;
  */
 export type CustomScript = {
   /**
+   * Milliseconds since epoch (host clock) when the inactivity watchdog was last refreshed. The cs-helper
+   * wrapper updates this whenever it calls {@link CustomScript.updateHeartBeat}; you can read it to see how
+   * long the run has been idle. If it is not refreshed for too long, the host ends execution (typically
+   * after about one minute without {@link CustomScript.log | `log`}, API activity, or a manual heartbeat).
+   */
+  heartBeat: number;
+
+  /**
+   * `true` after {@link CustomScript.close} has run for this execution. The cs-helper wrapper sets this so
+   * further {@link CustomScript.log | `log`}, {@link CustomScript.runApiRequest | `runApiRequest`}, and
+   * heartbeat updates are no-ops and the run is not treated as still active.
+   */
+  isClosed: boolean;
+
+  /**
    * API token for the authenticated user/context running this script, as configured in Metric Insights.
    */
   apiToken: string;
@@ -65,6 +80,18 @@ export type CustomScript = {
 
     [key: string]: string | number | boolean;
   };
+
+  /**
+   * Refreshes the inactivity watchdog and sets {@link CustomScript.heartBeat} to the current time. If the
+   * watchdog fires without a refresh, the Metric Insights runtime ends the run as hung.
+   *
+   * When you build with the cs-helper CLI, the bundled wrapper calls this automatically on successful
+   * {@link CustomScript.runApiRequest | `runApiRequest`} completions, on {@link CustomScript.log | `log`},
+   * and while waiting for a slow API response. Long stretches with no logging, no API traffic, and no manual
+   * calls—pure computation, tight loops, or idle `setTimeout` chains—are not covered; call this yourself in
+   * those paths or the run is typically cut off after about one minute of inactivity.
+   */
+  updateHeartBeat: () => void;
 
   /**
    * Performs an HTTP request to the Metric Insights backend. The host attaches credentials and uses the platform

--- a/templates/custom-script-js/src/index.js
+++ b/templates/custom-script-js/src/index.js
@@ -1,38 +1,51 @@
 import { cs, parseParams } from '@metricinsights/cs-helper';
 
+const CLOSE_DELAY_MS = 1000;
+
 /**
- * @type {{param1: string; param2?: string;}}
+ * @type {{param1: string; param2?: string; scriptTimeout: number;}}
  */
 const params = parseParams({
   param1: '',
+  scriptTimeout: 10 * 60 * 1000,
 });
+
+function scheduleClose() {
+  setTimeout(function () {
+    cs.close();
+  }, CLOSE_DELAY_MS);
+}
+
+setTimeout(function () {
+  if (cs.isClosed) {
+    return;
+  }
+
+  cs.log('Script exceeded scriptTimeout; closing.');
+  scheduleClose();
+}, params.scriptTimeout);
 
 async function main() {
   cs.result(`Hello, ${params.param1}! ${
     params.param2 ? `Your second parameter is ${params.param2}` : ''
   }`);
+
+  // Long CPU-bound work with no cs.log / runApiRequest: call cs.updateHeartBeat() in the loop
+  // so the inactivity watchdog (~1 minute) does not end the run early.
 }
 
-main().then(() => {
-  setTimeout(function () {
-    cs.close();
-  }, 1000);
-}).catch(function (e) {
-  cs.error(
-    e.responseText ||
-      e.message ||
-      (e.toString() === '[object Object]' ? JSON.stringify(e) : e.toString()),
-  );
-  cs.error(e.stack || 'No stack trace');
-  cs.error('Main execution error');
+main()
+  .then(() => {
+    scheduleClose();
+  })
+  .catch(function (e) {
+    cs.error(
+      e.responseText ||
+        e.message ||
+        (e.toString() === '[object Object]' ? JSON.stringify(e) : e.toString()),
+    );
+    cs.error(e.stack || 'No stack trace');
+    cs.error('Main execution error');
 
-  setTimeout(function () {
-    cs.close();
-  }, 1000);
-});
-
-setTimeout(function () {
-  cs.log('Something went wrong');
-
-  cs.close();
-}, 10 * 60 * 1000);
+    scheduleClose();
+  });

--- a/templates/custom-script-ts/src/index.ts
+++ b/templates/custom-script-ts/src/index.ts
@@ -1,11 +1,31 @@
 import { cs, parseParams } from '@metricinsights/cs-helper';
 
+const CLOSE_DELAY_MS = 1000;
+
 const params = parseParams<{
   param1: string;
   param2: string;
+  /** Maximum wall-clock time for this run (milliseconds). */
+  scriptTimeout: number;
 }>({
   param1: '',
+  scriptTimeout: 10 * 60 * 1000,
 });
+
+function scheduleClose() {
+  setTimeout(function () {
+    cs.close();
+  }, CLOSE_DELAY_MS);
+}
+
+setTimeout(function () {
+  if (cs.isClosed) {
+    return;
+  }
+
+  cs.log('Script exceeded scriptTimeout; closing.');
+  scheduleClose();
+}, params.scriptTimeout);
 
 async function main() {
   cs.result(
@@ -13,31 +33,23 @@ async function main() {
       params.param2 ? `Your second parameter is ${params.param2}` : ''
     }`,
   );
+
+  // Long CPU-bound work with no cs.log / runApiRequest: call cs.updateHeartBeat() in the loop
+  // so the inactivity watchdog (~1 minute) does not end the run early.
 }
 
-main().then(() => {
-  setTimeout(function () {
-    cs.close();
-  }, 1000);
-}).catch(function (e) {
-  cs.error(
-    e.responseText ||
-      e.message ||
-      (e.toString() === '[object Object]' ? JSON.stringify(e) : e.toString()),
-  );
-  cs.error(e.stack || 'No stack trace');
-  cs.error('Main execution error');
+main()
+  .then(() => {
+    scheduleClose();
+  })
+  .catch(function (e) {
+    cs.error(
+      e.responseText ||
+        e.message ||
+        (e.toString() === '[object Object]' ? JSON.stringify(e) : e.toString()),
+    );
+    cs.error(e.stack || 'No stack trace');
+    cs.error('Main execution error');
 
-  setTimeout(function () {
-    cs.close();
-  }, 1000);
-});
-
-setTimeout(
-  function () {
-    cs.log('Something went wrong');
-
-    cs.close();
-  },
-  10 * 60 * 1000,
-);
+    scheduleClose();
+  });

--- a/test/scaffold.spec.mjs
+++ b/test/scaffold.spec.mjs
@@ -10,7 +10,7 @@ const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, '..');
 
 /**
- * Basename of the copied pack artifact from `scripts/postbuild.js` (e.g. `metricinsights-cs-helper-latest.tgz`).
+ * Basename of the copied pack artifact from `scripts/postbuild.mjs` (e.g. `metricinsights-cs-helper-latest.tgz`).
  * Scaffold templates depend on `^%PLUGIN_VERSION%` from npm; unreleased versions are not on the registry, so
  * integration tests install from this local tarball instead (avoids ETARGET in CI).
  */


### PR DESCRIPTION
## Summary

- Document and type the Metric Insights custom script **lifecycle**: inactivity watchdog (`heartBeat` / `updateHeartBeat`, ~1 minute) vs wall-clock **`scriptTimeout`**.
- Update **scaffold templates** with `scheduleClose()`, a load-time safety timer, and guidance for manual heartbeat in silent loops.
- Fix **package build** so stale `dist/` artifacts are not published and the postbuild script no longer triggers Node ESM warnings.

## Changes

### `CustomScript` API (`src/index.ts`)
- `heartBeat`, `isClosed`, `updateHeartBeat()` with JSDoc describing wrapper auto-refresh on `log` / successful `runApiRequest` / slow API waits.

### Documentation
- README: *Inactivity watchdog* and *Finishing runs* sections.
- AI add-ons (Cursor rule, Claude.md): aligned author guidance.

### Templates
- `scriptTimeout` parameter (default 10 min), `scheduleClose()`, `cs.isClosed` guard on safety timeout.

### Build
- `npm run clean:dist` before `tsc`.
- `scripts/postbuild.mjs` replaces `postbuild.js`.

## Test plan

- [ ] `npm run build` — no warnings; tarball has no `dist/src/` or `dist/bin/bin/` duplicates.
- [ ] `npm test` — scaffold integration tests pass.
- [ ] Scaffold a new script and confirm `scriptTimeout` / `scheduleClose` pattern in generated entry file.

## Linear

PP-3534


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inactivity watchdog mechanism to prevent runs from being marked as hung; refresh during silent work periods.
  * Introduced `scriptTimeout`-based maximum wall-clock timeout pattern with automatic logging and closure.

* **Documentation**
  * Expanded guidance on proper script closure, heartbeat refresh timing, and timeout handling patterns.

* **Chores**
  * Updated build scripts and project templates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mi-examples/cs-helper/pull/35?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->