### PR TITLE
pp-3534: fix cli bin execute bit for linux npm exec

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "npm run clean:dist && npm run build:sources && npm run build:bin",
     "postbuild": "npm pack && node scripts/postbuild.mjs",
     "build:sources": "tsc",
-    "build:bin": "tsc --project tsconfig.bin.json",
+    "build:bin": "tsc --project tsconfig.bin.json && node scripts/chmod-bin.cjs",
     "test": "playwright test",
     "release": "semantic-release",
     "version": "npm version --commit-hooks false --git-tag-version false",

--- a/scripts/chmod-bin.cjs
+++ b/scripts/chmod-bin.cjs
@@ -1,0 +1,19 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+if (process.platform === 'win32') {
+  process.exit(0);
+}
+
+const binDir = path.join(__dirname, '..', 'dist', 'bin');
+const mode = 0o755;
+
+for (const name of ['build.js', 'create.js']) {
+  const filePath = path.join(binDir, name);
+
+  if (fs.existsSync(filePath)) {
+    fs.chmodSync(filePath, mode);
+  }
+}


### PR DESCRIPTION
## Summary

Fix CI failure `cs-helper-create: Permission denied` on Linux when running the `npm exec` scaffold integration test.

## Changes

- Add `scripts/chmod-bin.cjs` to set mode `755` on `dist/bin/build.js` and `dist/bin/create.js` after `tsc` (no-op on Windows).
- Run it from `build:bin` so published bins and local `npm exec` work on Unix.

## Test plan

- [x] `npm test` — all 10 scaffold tests pass locally, including `npm create flow + install for custom-script-js`
- [ ] GitHub Actions `npm test` on Ubuntu

## Linear

PP-3534

**Merge Request:** `origin/pp-3534` → `origin/develop`
