### PR TITLE
chore: merge develop into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [0.8.1-beta.1](https://github.com/mi-examples/cs-helper/compare/v0.8.0...v0.8.1-beta.1) (2026-05-26)
+
+
+### Bug Fixes
+
+* **params:** show optional number params as number in docs ([c0b8632](https://github.com/mi-examples/cs-helper/commit/c0b863207b053e8b5e3cdc1e38f89b21dfc8dd52))
+* **parseParams:** allow optional properties in generic constraint ([2580cdc](https://github.com/mi-examples/cs-helper/commit/2580cdc857d88153e215ff0cd8897050acee7c62))
+
 # [0.8.0-beta.1](https://github.com/mi-examples/cs-helper/compare/v0.7.2...v0.8.0-beta.1) (2026-05-26)
 
 

--- a/bin/params-docs.ts
+++ b/bin/params-docs.ts
@@ -1,5 +1,6 @@
 const pathLib = require('path');
 const fs = require('fs');
+const { getGenericTypeDisplay } = require('./params-type-display');
 
 export type ParamRow = {
   name: string;
@@ -270,112 +271,6 @@ function getJSDocParamInfo(ts: any, decl: any): JSDocParamInfo {
 }
 
 /**
- * Maps a type to only generic primitive(s): string, number, boolean.
- * Used for the table Type column; object/custom types are not accepted.
- */
-function getGenericTypeDisplay(
-  checker: any,
-  type: any,
-  seen = new Set<number>(),
-): string {
-  if (!type) {
-    return 'any';
-  }
-
-  const id = type.id ?? type.flags;
-
-  if (id != null && seen.has(id)) {
-    return '';
-  }
-
-  if (id != null) {
-    seen.add(id);
-  }
-
-  const primitives = new Set<string>();
-  const add = (s: string) => s && primitives.add(s);
-
-  if (type.types && Array.isArray(type.types)) {
-    for (const t of type.types) {
-      const r = getGenericTypeDisplay(checker, t, seen);
-
-      if (r && r !== 'any') {
-        r.split(/\s*\|\s*/).forEach((p) => add(p.trim()));
-      }
-    }
-
-    const arr = [...primitives].sort();
-
-    return arr.length ? arr.join(' | ') : 'any';
-  }
-
-  if (type.value !== undefined && type.value !== null) {
-    const v = type.value;
-
-    if (typeof v === 'string') {
-      return 'string';
-    }
-
-    if (typeof v === 'number') {
-      return 'number';
-    }
-
-    if (v === true || v === false) {
-      return 'boolean';
-    }
-  }
-
-  if (type.flags != null) {
-    const f = type.flags;
-
-    if (f & 4) {
-      return 'string';
-    }
-
-    if (f & 8) {
-      return 'number';
-    }
-
-    if (f & 16) {
-      return 'boolean';
-    }
-  }
-
-  if (type.symbol && typeof checker.getDeclaredTypeOfSymbol === 'function') {
-    try {
-      const declared = checker.getDeclaredTypeOfSymbol(type.symbol);
-
-      if (declared && declared !== type) {
-        const r = getGenericTypeDisplay(checker, declared, seen);
-
-        if (r && r !== 'any') {
-          return r;
-        }
-      }
-    } catch {
-      //
-    }
-  }
-
-  if (typeof checker.typeToString === 'function') {
-    try {
-      const str = checker.typeToString(type).trim().toLowerCase();
-
-      if (str === 'boolean' || str === 'string' || str === 'number') {
-        return str;
-      }
-
-      if (str === 'true' || str === 'false') {
-        return 'boolean';
-      }
-    } catch {
-      //
-    }
-  }
-  return '';
-}
-
-/**
  * Collects literal values from a type (union of literals or type alias resolving to same).
  * Used to document "Can accept values: `a, b, c`" for enum-like params.
  */
@@ -482,7 +377,7 @@ function expandTypeToParamRows(
         const decl = sym.valueDeclaration || sym.declarations?.[0];
         const optional = !!(decl && decl.questionToken);
         const propType = checker.getTypeOfSymbolAtLocation(sym, typeNode);
-        let typeStr = getGenericTypeDisplay(checker, propType) || 'any';
+        let typeStr = getGenericTypeDisplay(ts, checker, propType) || 'any';
         const jsdoc = getJSDocParamInfo(ts, decl);
         if (jsdoc.password && typeStr === 'string') {
           typeStr = 'password';
@@ -503,7 +398,7 @@ function expandTypeToParamRows(
     const stringIndex = type.getStringIndexType?.();
 
     if (stringIndex) {
-      const typeStr = getGenericTypeDisplay(checker, stringIndex) || 'any';
+      const typeStr = getGenericTypeDisplay(ts, checker, stringIndex) || 'any';
 
       rows.push({
         name: '[key: string]',
@@ -516,7 +411,7 @@ function expandTypeToParamRows(
     const numberIndex = type.getNumberIndexType?.();
 
     if (numberIndex) {
-      const typeStr = getGenericTypeDisplay(checker, numberIndex) || 'any';
+      const typeStr = getGenericTypeDisplay(ts, checker, numberIndex) || 'any';
 
       rows.push({
         name: '[key: number]',

--- a/bin/params-type-display.ts
+++ b/bin/params-type-display.ts
@@ -1,0 +1,211 @@
+/**
+ * Resolves parameter primitive types for docs/base64 tables from TypeScript checker types.
+ *
+ * TypeScript 5.x and 6.x use different numeric {@link TypeFlags} values (e.g. `Undefined`
+ * was `32768` in 5.x and is `4` in 6.x, which used to be `String` in 5.x). Always pass
+ * the same `ts` module instance that created the `checker` and read flags via `ts.TypeFlags`
+ * — never hard-coded bit masks.
+ */
+
+/** TypeFlags layout from TypeScript 5.x (checker types use these bit values). */
+export const TYPE_FLAGS_TYPESCRIPT_5 = {
+  String: 4,
+  Number: 8,
+  Boolean: 16,
+  Undefined: 32768,
+  Null: 65536,
+  Void: 16384,
+  Union: 1048576,
+} as const;
+
+/** TypeFlags layout from TypeScript 6.x. */
+export const TYPE_FLAGS_TYPESCRIPT_6 = {
+  String: 32,
+  Number: 64,
+  Boolean: 256,
+  Undefined: 4,
+  Null: 8,
+  Void: 16,
+  Union: 134217728,
+} as const;
+
+export type TypeFlagsLike = {
+  String: number;
+  Number: number;
+  Boolean: number;
+  Undefined: number;
+  Null: number;
+  Void: number;
+  Union?: number;
+};
+
+export function getTypeScriptMajorVersion(ts: { version?: string }): number {
+  const major = parseInt(String(ts.version ?? '0').split('.')[0], 10);
+
+  return Number.isFinite(major) ? major : 0;
+}
+
+/**
+ * Returns true when `ts.TypeFlags` matches the TypeScript 6+ layout (Undefined === 4).
+ */
+export function isTypeScript6TypeFlags(TF: TypeFlagsLike): boolean {
+  return TF.Undefined === TYPE_FLAGS_TYPESCRIPT_6.Undefined;
+}
+
+/**
+ * Minimal mock `ts` for tests: supply a TypeFlags-like object (TS 5 or TS 6 layout).
+ */
+export function createTypeScriptApiStub(typeFlags: TypeFlagsLike): {
+  TypeFlags: TypeFlagsLike;
+  version: string;
+} {
+  const major = isTypeScript6TypeFlags(typeFlags) ? 6 : 5;
+
+  return {
+    TypeFlags: typeFlags,
+    version: `${major}.0.0`,
+  };
+}
+
+/**
+ * Maps a checker type to generic primitive name(s): `string`, `number`, `boolean`.
+ */
+export function getGenericTypeDisplay(
+  ts: { TypeFlags: TypeFlagsLike },
+  checker: {
+    getDeclaredTypeOfSymbol?: (symbol: unknown) => unknown;
+    typeToString?: (type: unknown) => string;
+  },
+  type: {
+    id?: number;
+    flags?: number;
+    types?: unknown[];
+    value?: unknown;
+    symbol?: unknown;
+  } | null
+  | undefined,
+  seen = new Set<number>(),
+): string {
+  if (!type) {
+    return 'any';
+  }
+
+  const TF = ts.TypeFlags;
+  const isAbsentPrimitive = (t: { flags?: number }) => {
+    const f = t?.flags ?? 0;
+
+    return !!(f & (TF.Undefined | TF.Null | TF.Void));
+  };
+
+  const id = type.id ?? type.flags;
+
+  if (id != null && seen.has(id)) {
+    return '';
+  }
+
+  if (id != null) {
+    seen.add(id);
+  }
+
+  const primitives = new Set<string>();
+  const add = (s: string) => s && primitives.add(s);
+
+  if (type.types && Array.isArray(type.types)) {
+    for (const t of type.types) {
+      if (isAbsentPrimitive(t as { flags?: number })) {
+        continue;
+      }
+
+      const r = getGenericTypeDisplay(
+        ts,
+        checker,
+        t as typeof type,
+        seen,
+      );
+
+      if (r && r !== 'any') {
+        r.split(/\s*\|\s*/).forEach((p) => add(p.trim()));
+      }
+    }
+
+    const arr = [...primitives].sort();
+
+    return arr.length ? arr.join(' | ') : 'any';
+  }
+
+  if (isAbsentPrimitive(type)) {
+    return '';
+  }
+
+  if (type.value !== undefined && type.value !== null) {
+    const v = type.value;
+
+    if (typeof v === 'string') {
+      return 'string';
+    }
+
+    if (typeof v === 'number') {
+      return 'number';
+    }
+
+    if (v === true || v === false) {
+      return 'boolean';
+    }
+  }
+
+  if (type.flags != null) {
+    const f = type.flags;
+
+    if (f & TF.String) {
+      return 'string';
+    }
+
+    if (f & TF.Number) {
+      return 'number';
+    }
+
+    if (f & TF.Boolean) {
+      return 'boolean';
+    }
+  }
+
+  if (type.symbol && typeof checker.getDeclaredTypeOfSymbol === 'function') {
+    try {
+      const declared = checker.getDeclaredTypeOfSymbol(type.symbol) as
+        | typeof type
+        | undefined;
+
+      if (declared && declared !== type) {
+        const r = getGenericTypeDisplay(ts, checker, declared, seen);
+
+        if (r && r !== 'any') {
+          return r;
+        }
+      }
+    } catch {
+      //
+    }
+  }
+
+  if (typeof checker.typeToString === 'function') {
+    try {
+      const str = checker.typeToString(type).trim().toLowerCase();
+
+      if (str === 'undefined' || str === 'null' || str === 'void') {
+        return '';
+      }
+
+      if (str === 'boolean' || str === 'string' || str === 'number') {
+        return str;
+      }
+
+      if (str === 'true' || str === 'false') {
+        return 'boolean';
+      }
+    } catch {
+      //
+    }
+  }
+
+  return '';
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@metricinsights/cs-helper",
-  "version": "0.8.0-beta.1",
+  "version": "0.8.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@metricinsights/cs-helper",
-      "version": "0.8.0-beta.1",
+      "version": "0.8.1-beta.1",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metricinsights/cs-helper",
-  "version": "0.8.0-beta.1",
+  "version": "0.8.1-beta.1",
   "description": "Helper for Custom Scripts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,20 @@ import './polyfill';
 type ParametersType = Record<string, string | number | boolean>;
 
 /**
+ * Allowed value types for a single script parameter key (Metric Insights scalars).
+ * Optional properties on {@link parseParams} maps may be `undefined` before merge.
+ */
+export type ScriptParameterValue = string | number | boolean;
+
+/**
+ * Validates that each key on a {@link parseParams} map is a Metric Insights scalar
+ * (`string`, `number`, or `boolean`), including optional properties (`T[K]` may be `undefined`).
+ */
+export type ValidScriptParameters<T> = {
+  [K in keyof T]: [T[K]] extends [ScriptParameterValue | undefined] ? T[K] : never;
+};
+
+/**
  * Runtime surface injected by the Metric Insights custom script host. Your bundle runs with a global
  * **`customScript`** instance (see {@link cs}) exposing identity, configuration, logging, HTTP access, and lifecycle.
  *
@@ -162,11 +176,9 @@ export const cs = customScript;
  * @param defaultParams Default values for parameters when the host does not supply them. May be a partial map.
  * @returns The merged parameter object (`defaultParams` ⊕ `cs.parameters`).
  */
-export function parseParams<
-  T extends {
-    [K in keyof T]: T[K] extends string | number | boolean ? T[K] : never;
-  } = ParametersType,
->(defaultParams: Partial<T> = {}): T {
+export function parseParams<T extends ValidScriptParameters<T> = ParametersType>(
+  defaultParams: Partial<T> = {},
+): T {
   const params = Object.assign(
     {},
     defaultParams,

--- a/test-fixtures/optional-number-params.ts
+++ b/test-fixtures/optional-number-params.ts
@@ -1,0 +1,18 @@
+import { parseParams } from '../src/index';
+
+export interface ScriptParams {
+  pageId: string;
+  scriptTimeout?: number;
+  excludedReportNamesDatasetId?: number;
+  minItemsCount?: number;
+  minPairDice?: number;
+  requiredNum: number;
+}
+
+parseParams<ScriptParams>({
+  pageId: '',
+  requiredNum: 1,
+  scriptTimeout: 600000,
+  minItemsCount: 8,
+  minPairDice: 0.15,
+});

--- a/test-fixtures/password-param.ts
+++ b/test-fixtures/password-param.ts
@@ -1,0 +1,8 @@
+import { parseParams } from '../src/index';
+
+export interface ScriptParams {
+  /** API secret. @password */
+  apiToken?: string;
+}
+
+parseParams<ScriptParams>({});

--- a/test-fixtures/tsconfig.json
+++ b/test-fixtures/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "lib": ["es2015", "dom"],
+    "module": "es2015",
+    "moduleResolution": "bundler",
+    "target": "es2015",
+    "rootDir": ".."
+  },
+  "include": ["./**/*.ts", "../src/**/*.ts"]
+}

--- a/test/params-docs.spec.mjs
+++ b/test/params-docs.spec.mjs
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import ts from 'typescript';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+
+test('optional number params are not widened to number | string (installed TS)', async () => {
+  test.info().annotations.push({
+    type: 'typescript',
+    description: ts.version,
+  });
+  const { analyzeParseParamsData } = await import(
+    pathToFileURL(path.join(repoRoot, 'dist/bin/params-docs.js')).href
+  );
+
+  const fixture = path.join(repoRoot, 'test-fixtures/optional-number-params.ts');
+  const [call] = analyzeParseParamsData(fixture);
+
+  expect(call?.typeInfoTable).toBeDefined();
+
+  const byName = Object.fromEntries(
+    call.typeInfoTable.map((row) => [row.name, row]),
+  );
+
+  expect(byName.scriptTimeout.typeStr).toBe('number');
+  expect(byName.excludedReportNamesDatasetId.typeStr).toBe('number');
+  expect(byName.minItemsCount.typeStr).toBe('number');
+  expect(byName.minPairDice.typeStr).toBe('number');
+  expect(byName.requiredNum.typeStr).toBe('number');
+});
+
+test('@password JSDoc maps string param type to password', async () => {
+  const { analyzeParseParamsData } = await import(
+    pathToFileURL(path.join(repoRoot, 'dist/bin/params-docs.js')).href
+  );
+
+  const fixture = path.join(repoRoot, 'test-fixtures/password-param.ts');
+  const [call] = analyzeParseParamsData(fixture);
+  const apiToken = call?.typeInfoTable?.find((row) => row.name === 'apiToken');
+
+  expect(apiToken?.typeStr).toBe('password');
+  expect(apiToken?.optional).toBe(true);
+});

--- a/test/params-type-display.spec.mjs
+++ b/test/params-type-display.spec.mjs
@@ -1,0 +1,168 @@
+import { test, expect } from '@playwright/test';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import ts from 'typescript';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+
+const displayUrl = pathToFileURL(
+  path.join(repoRoot, 'dist/bin/params-type-display.js'),
+).href;
+
+const noopChecker = {
+  typeToString(type) {
+    if (type.label) {
+      return type.label;
+    }
+
+    return '';
+  },
+};
+
+test.describe('getGenericTypeDisplay with TypeScript 5 TypeFlags layout', () => {
+  let ts5Api;
+
+  test.beforeAll(async () => {
+    const {
+      createTypeScriptApiStub,
+      TYPE_FLAGS_TYPESCRIPT_5,
+    } = await import(displayUrl);
+
+    ts5Api = createTypeScriptApiStub(TYPE_FLAGS_TYPESCRIPT_5);
+  });
+
+  test('optional number union (number | undefined) resolves to number', async () => {
+    const { getGenericTypeDisplay } = await import(displayUrl);
+    const TF = ts5Api.TypeFlags;
+
+    expect(
+      getGenericTypeDisplay(ts5Api, noopChecker, {
+        types: [{ flags: TF.Undefined }, { flags: TF.Number }],
+      }),
+    ).toBe('number');
+  });
+
+  test('string primitive uses String flag (4), not confused with Undefined', async () => {
+    const { getGenericTypeDisplay } = await import(displayUrl);
+
+    expect(
+      getGenericTypeDisplay(ts5Api, noopChecker, {
+        flags: ts5Api.TypeFlags.String,
+      }),
+    ).toBe('string');
+  });
+
+  test('boolean and number primitives', async () => {
+    const { getGenericTypeDisplay } = await import(displayUrl);
+    const TF = ts5Api.TypeFlags;
+
+    expect(getGenericTypeDisplay(ts5Api, noopChecker, { flags: TF.Boolean })).toBe(
+      'boolean',
+    );
+    expect(getGenericTypeDisplay(ts5Api, noopChecker, { flags: TF.Number })).toBe(
+      'number',
+    );
+  });
+});
+
+test.describe('getGenericTypeDisplay with TypeScript 6 TypeFlags layout', () => {
+  let ts6Api;
+
+  test.beforeAll(async () => {
+    const {
+      createTypeScriptApiStub,
+      TYPE_FLAGS_TYPESCRIPT_6,
+    } = await import(displayUrl);
+
+    ts6Api = createTypeScriptApiStub(TYPE_FLAGS_TYPESCRIPT_6);
+  });
+
+  test('optional number union (number | undefined) resolves to number', async () => {
+    const { getGenericTypeDisplay } = await import(displayUrl);
+    const TF = ts6Api.TypeFlags;
+
+    expect(
+      getGenericTypeDisplay(ts6Api, noopChecker, {
+        types: [{ flags: TF.Undefined }, { flags: TF.Number }],
+      }),
+    ).toBe('number');
+  });
+
+  test('Undefined flag (4) is not reported as string', async () => {
+    const { getGenericTypeDisplay } = await import(displayUrl);
+    const TF = ts6Api.TypeFlags;
+
+    expect(getGenericTypeDisplay(ts6Api, noopChecker, { flags: TF.Undefined })).toBe(
+      '',
+    );
+    expect(
+      getGenericTypeDisplay(ts6Api, noopChecker, {
+        types: [{ flags: TF.Undefined }, { flags: TF.Number }],
+      }),
+    ).toBe('number');
+  });
+
+  test('string primitive uses String flag (32)', async () => {
+    const { getGenericTypeDisplay } = await import(displayUrl);
+
+    expect(
+      getGenericTypeDisplay(ts6Api, noopChecker, {
+        flags: ts6Api.TypeFlags.String,
+      }),
+    ).toBe('string');
+  });
+});
+
+test.describe('installed typescript package', () => {
+  test('TypeFlags layout matches major version', async () => {
+    const {
+      getTypeScriptMajorVersion,
+      isTypeScript6TypeFlags,
+    } = await import(displayUrl);
+
+    const major = getTypeScriptMajorVersion(ts);
+    const layoutIsTs6 = isTypeScript6TypeFlags(ts.TypeFlags);
+
+    expect(major).toBeGreaterThanOrEqual(5);
+    expect(layoutIsTs6).toBe(major >= 6);
+  });
+
+  test('optional number from real checker matches installed layout', async () => {
+    const { getGenericTypeDisplay } = await import(displayUrl);
+    const entry = path.join(repoRoot, 'test-fixtures/optional-number-params.ts');
+    const program = ts.createProgram([entry, path.join(repoRoot, 'src/index.ts')], {
+      allowJs: true,
+      noEmit: true,
+      skipLibCheck: true,
+    });
+    const checker = program.getTypeChecker();
+    const sf = program.getSourceFile(entry);
+
+    let propType;
+
+    function visit(node) {
+      if (
+        ts.isCallExpression(node) &&
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === 'parseParams'
+      ) {
+        const typeNode = node.typeArguments[0];
+
+        for (const sym of checker.getPropertiesOfType(
+          checker.getTypeFromTypeNode(typeNode),
+        )) {
+          if (sym.getName() === 'scriptTimeout') {
+            propType = checker.getTypeOfSymbolAtLocation(sym, typeNode);
+          }
+        }
+      }
+
+      ts.forEachChild(node, visit);
+    }
+
+    visit(sf);
+
+    expect(getGenericTypeDisplay(ts, checker, propType)).toBe('number');
+  });
+});

--- a/tsconfig.bin.json
+++ b/tsconfig.bin.json
@@ -1,10 +1,9 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "ignoreDeprecations": "6.0",
     "lib": ["esnext"],
     "module": "commonjs",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "removeComments": true,
     "rootDir": "./bin",
     "sourceMap": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,15 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "ignoreDeprecations": "6.0",
     "lib": ["es2015", "dom"],
     "module": "es2015",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "removeComments": true,
     "rootDir": "./src",
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
-    "target": "es5",
+    "target": "es2015",
     "outDir": "./dist"
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
## Summary

Merge `develop` into `main`.

## Included changes

- Fix `parseParams` docs/base64 generation: optional `number` params no longer show as `number | string` after TypeScript 6 `TypeFlags` changes.
- Relax `parseParams` generic constraint for optional properties.
- Add regression tests (TypeFlags TS 5/6 layouts, optional numbers, `@password`).
- Align `tsconfig` with TS 6 (`moduleResolution: bundler`, `target: es2015`).

## Included commits

- 008a70f Merge pull request #38 from mi-examples/pp-3541
- 1f80a67 build(tsconfig): align compiler options with TypeScript 6
- 46f9178 test(params): add regression tests for docs and TypeFlags layouts
- 2580cdc fix(parseParams): allow optional properties in generic constraint
- c0b8632 fix(params): show optional number params as number in docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes – v0.8.1-beta.1

* **Bug Fixes**
  * Corrected documentation formatting for optional numeric parameters
  * Improved parameter parsing to properly support optional property constraints

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mi-examples/cs-helper/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->